### PR TITLE
fix(ci): complexity-check.yml の actions を SHA pin に変更

### DIFF
--- a/.github/workflows/complexity-check.yml
+++ b/.github/workflows/complexity-check.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
           node-version: "20"
           cache: "npm"


### PR DESCRIPTION
## Summary

- `actions_sha_pinning_required = true` (terraform 側で有効化) のため、tag 参照のままだと `Cyclomatic Complexity Check` workflow が `startup_failure` する
- 結果として必須ステータスチェック `Check Cyclomatic Complexity` が未送信のままになり、すべての PR が `mergeStateStatus: BLOCKED` から動かなくなる（#28 が顕在化したケース）
- `actions/checkout` と `actions/setup-node` を SHA pin に変更（他 workflow と表記統一）

## Context

`../genzouw.com` の terraform IaC (`terraform/environments/github/main.tf:140-141`) で:

```hcl
manage_actions_sha_pinning   = true
actions_sha_pinning_required = true
```

terraform 側のコメント (main.tf:137-139) に「既存 workflow が tag 参照のままなら apply 後に CI が一度落ちるため、別 PR で workflow 側を SHA pin 化する流れになる」と明記されており、これがその「別 PR」にあたる。

## Test plan

- [ ] この PR 上で `Cyclomatic Complexity Check` workflow が `startup_failure` ではなく実行 → 成功すること
- [ ] マージ後、PR #28 を main 取り込みで再 run し、`Check Cyclomatic Complexity` が success になり mergeStateStatus が CLEAN になること

## Followup（このPRの範囲外）

以下も同じ理由で startup_failure 中。順次別 PR で対応が必要：

- `.github/workflows/deploy.yml` の `actions/checkout@v4` / `aws-actions/configure-aws-credentials@v4` → SHA pin（※ PR #28 マージ後に対応するのが整理しやすい）
- `.github/workflows/markdownlint.yml` の `DavidAnson/markdownlint-cli2-action` は Verified Creator ではないため、`actions_patterns_allowed` に追加するか別 action へ差し替えが必要（SHA pin 化とは別軸の問題）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CDワークフローの依存関係を最新の安定版に更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/kakezan-manabo/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->