### PR TITLE
refactor: 💡 storage.jsのloadSettings/saveSettings関数の責務分離

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,11 +1,11 @@
-import { generateMultiplicationQuestion, generateChoices } from './logic.js';
+import { generateMultiplicationQuestion, generateChoices } from "./logic.js";
 import {
   speakQuestion,
   speakAnswer,
   speakQuestionAndAnswer,
   playCorrectSound,
   playIncorrectSound,
-} from './audio.js';
+} from "./audio.js";
 import {
   loadSettings,
   saveSettings,
@@ -17,7 +17,7 @@ import {
   loadCharacterXP,
   addCharacterXP,
   recordTodayStudy,
-} from './storage.js';
+} from "./storage.js";
 import {
   updateQuestionProgress,
   displayHistory,
@@ -25,37 +25,38 @@ import {
   displayCharacter,
   showLevelUpModal,
   displayRewardCalendar,
-} from './ui.js';
-import { updateQuestionStats } from './analytics.js';
+} from "./ui.js";
+import { updateQuestionStats } from "./analytics.js";
 import {
   updateModeDescription,
   applySettingsToDOM,
   readSettingsFromDOM,
-} from './ui-helper.js';
+} from "./ui-helper.js";
 import {
   updateAchievementStats,
   updateStreak,
   checkNewBadges,
   showBadgeModal,
-} from './badges.js';
-import { displayBadgeCollection } from './badge-display.js';
-import { updateAllCharts } from './charts.js';
-import { MenuManager } from './menu.js';
-import { calculateXP, hasLeveledUp, getCurrentLevel } from './character.js';
+} from "./badges.js";
+import { displayBadgeCollection } from "./badge-display.js";
+import { updateAllCharts } from "./charts.js";
+import { MenuManager } from "./menu.js";
+import { calculateXP, hasLeveledUp, getCurrentLevel } from "./character.js";
 
 // レベルアップモーダル表示の遅延時間（ミリ秒）
 const LEVEL_UP_MODAL_DELAY_MS = 2500;
 
 let totalQuestions = 10;
-let learningMode = 'normal';
+let learningMode = "normal";
+let selectedLevels = null;
 
-document.addEventListener('DOMContentLoaded', function () {
+document.addEventListener("DOMContentLoaded", function () {
   // メニューマネージャーを初期化
   const menuManager = new MenuManager();
 
-  const questionDiv = document.getElementById('question');
-  const choiceButtons = document.querySelectorAll('.choice-btn');
-  const startButton = document.getElementById('start-btn');
+  const questionDiv = document.getElementById("question");
+  const choiceButtons = document.querySelectorAll(".choice-btn");
+  const startButton = document.getElementById("start-btn");
 
   let currentQuestion;
   let currentQuestionIndex = 0;
@@ -65,9 +66,6 @@ document.addEventListener('DOMContentLoaded', function () {
   let gameStartTime = null;
 
   async function displayQuestion() {
-    const selectedLevels = Array.from(
-      document.querySelectorAll('#settings input[type="checkbox"]:checked'),
-    ).map((checkbox) => parseInt(checkbox.value));
     currentQuestion = generateMultiplicationQuestion(
       completedQuestions,
       selectedLevels,
@@ -79,7 +77,7 @@ document.addEventListener('DOMContentLoaded', function () {
     questionDiv.textContent = currentQuestion.question;
     displayChoices();
     choiceButtons.forEach((button) => {
-      button.style.backgroundColor = '#f0f0f0';
+      button.style.backgroundColor = "#f0f0f0";
       button.style.opacity = 1;
     });
     await speakQuestion(currentQuestion.reading);
@@ -110,7 +108,7 @@ document.addEventListener('DOMContentLoaded', function () {
     // 連続正解数を更新
     updateStreak(isCorrect);
 
-    correctAnswerButton.style.backgroundColor = 'lightgreen';
+    correctAnswerButton.style.backgroundColor = "lightgreen";
     if (isCorrect) {
       correctAnswers++;
       playCorrectSound();
@@ -138,7 +136,7 @@ document.addEventListener('DOMContentLoaded', function () {
       // キャラクター表示を更新
       displayCharacter(newXP);
     } else {
-      selectedButton.style.backgroundColor = 'pink';
+      selectedButton.style.backgroundColor = "pink";
       playIncorrectSound();
       // 不正解時も問題と答えをセットで読み上げる
       speakQuestionAndAnswer(
@@ -202,16 +200,16 @@ document.addEventListener('DOMContentLoaded', function () {
     displayRewardCalendar();
 
     questionDiv.textContent = `せいかいは ${correctAnswers}こ だったよ！`;
-    choiceButtons.forEach((button) => (button.style.display = 'none'));
-    startButton.style.display = 'inline-block';
+    choiceButtons.forEach((button) => (button.style.display = "none"));
+    startButton.style.display = "inline-block";
   }
 
-  startButton.addEventListener('click', function () {
+  startButton.addEventListener("click", function () {
     currentQuestionIndex = 0;
     correctAnswers = 0;
     gameStartTime = Date.now();
-    startButton.style.display = 'none';
-    choiceButtons.forEach((button) => (button.style.display = 'inline-block'));
+    startButton.style.display = "none";
+    choiceButtons.forEach((button) => (button.style.display = "inline-block"));
     displayQuestion();
     updateQuestionProgress(currentQuestionIndex);
   });
@@ -220,6 +218,9 @@ document.addEventListener('DOMContentLoaded', function () {
   applySettingsToDOM(settings);
   totalQuestions = settings.questionCount;
   learningMode = settings.learningMode;
+  selectedLevels = Array.from(
+    document.querySelectorAll('#settings input[type="checkbox"]:checked'),
+  ).map((checkbox) => parseInt(checkbox.value));
   gameHistory = loadHistory();
   displayHistory(gameHistory);
   displayBadgeCollection();
@@ -233,24 +234,25 @@ document.addEventListener('DOMContentLoaded', function () {
     saveSettings(newSettings);
     totalQuestions = newSettings.questionCount;
     learningMode = newSettings.learningMode;
+    selectedLevels = newSettings.selectedLevels;
     return newSettings;
   }
 
   document
     .querySelectorAll('#settings input[type="checkbox"]')
     .forEach((checkbox) => {
-      checkbox.addEventListener('change', () => {
+      checkbox.addEventListener("change", () => {
         persistSettingsFromDOM();
       });
     });
 
-  document.getElementById('questionCount').addEventListener('change', () => {
+  document.getElementById("questionCount").addEventListener("change", () => {
     persistSettingsFromDOM();
   });
 
-  const modeSelect = document.getElementById('learningMode');
+  const modeSelect = document.getElementById("learningMode");
   if (modeSelect) {
-    modeSelect.addEventListener('change', () => {
+    modeSelect.addEventListener("change", () => {
       persistSettingsFromDOM();
       updateModeDescription();
     });

--- a/js/main.js
+++ b/js/main.js
@@ -1,11 +1,11 @@
-import { generateMultiplicationQuestion, generateChoices } from "./logic.js";
+import { generateMultiplicationQuestion, generateChoices } from './logic.js';
 import {
   speakQuestion,
   speakAnswer,
   speakQuestionAndAnswer,
   playCorrectSound,
   playIncorrectSound,
-} from "./audio.js";
+} from './audio.js';
 import {
   loadSettings,
   saveSettings,
@@ -17,34 +17,45 @@ import {
   loadCharacterXP,
   addCharacterXP,
   recordTodayStudy,
-} from "./storage.js";
-import { updateQuestionProgress, displayHistory, displayMistakeNotebook, displayCharacter, showLevelUpModal, displayRewardCalendar } from "./ui.js";
-import { updateQuestionStats } from "./analytics.js";
-import { updateModeDescription } from "./ui-helper.js";
+} from './storage.js';
+import {
+  updateQuestionProgress,
+  displayHistory,
+  displayMistakeNotebook,
+  displayCharacter,
+  showLevelUpModal,
+  displayRewardCalendar,
+} from './ui.js';
+import { updateQuestionStats } from './analytics.js';
+import {
+  updateModeDescription,
+  applySettingsToDOM,
+  readSettingsFromDOM,
+} from './ui-helper.js';
 import {
   updateAchievementStats,
   updateStreak,
   checkNewBadges,
   showBadgeModal,
-} from "./badges.js";
-import { displayBadgeCollection } from "./badge-display.js";
-import { updateAllCharts } from "./charts.js";
-import { MenuManager } from "./menu.js";
-import { calculateXP, hasLeveledUp, getCurrentLevel } from "./character.js";
+} from './badges.js';
+import { displayBadgeCollection } from './badge-display.js';
+import { updateAllCharts } from './charts.js';
+import { MenuManager } from './menu.js';
+import { calculateXP, hasLeveledUp, getCurrentLevel } from './character.js';
 
 // レベルアップモーダル表示の遅延時間（ミリ秒）
 const LEVEL_UP_MODAL_DELAY_MS = 2500;
 
 let totalQuestions = 10;
-let learningMode = "normal";
+let learningMode = 'normal';
 
-document.addEventListener("DOMContentLoaded", function () {
+document.addEventListener('DOMContentLoaded', function () {
   // メニューマネージャーを初期化
   const menuManager = new MenuManager();
 
-  const questionDiv = document.getElementById("question");
-  const choiceButtons = document.querySelectorAll(".choice-btn");
-  const startButton = document.getElementById("start-btn");
+  const questionDiv = document.getElementById('question');
+  const choiceButtons = document.querySelectorAll('.choice-btn');
+  const startButton = document.getElementById('start-btn');
 
   let currentQuestion;
   let currentQuestionIndex = 0;
@@ -60,7 +71,7 @@ document.addEventListener("DOMContentLoaded", function () {
     currentQuestion = generateMultiplicationQuestion(
       completedQuestions,
       selectedLevels,
-      learningMode
+      learningMode,
     );
     if (currentQuestion === null) {
       return;
@@ -68,7 +79,7 @@ document.addEventListener("DOMContentLoaded", function () {
     questionDiv.textContent = currentQuestion.question;
     displayChoices();
     choiceButtons.forEach((button) => {
-      button.style.backgroundColor = "#f0f0f0";
+      button.style.backgroundColor = '#f0f0f0';
       button.style.opacity = 1;
     });
     await speakQuestion(currentQuestion.reading);
@@ -99,12 +110,15 @@ document.addEventListener("DOMContentLoaded", function () {
     // 連続正解数を更新
     updateStreak(isCorrect);
 
-    correctAnswerButton.style.backgroundColor = "lightgreen";
+    correctAnswerButton.style.backgroundColor = 'lightgreen';
     if (isCorrect) {
       correctAnswers++;
       playCorrectSound();
       // 正解時も問題と答えをセットで読み上げる
-      speakQuestionAndAnswer(currentQuestion.reading, currentQuestion.answerReading);
+      speakQuestionAndAnswer(
+        currentQuestion.reading,
+        currentQuestion.answerReading,
+      );
       // 正解時に連続正解カウントを更新（間違いノートに登録されている場合）
       updateCorrectStreak(currentQuestion.questionKey);
 
@@ -124,10 +138,13 @@ document.addEventListener("DOMContentLoaded", function () {
       // キャラクター表示を更新
       displayCharacter(newXP);
     } else {
-      selectedButton.style.backgroundColor = "pink";
+      selectedButton.style.backgroundColor = 'pink';
       playIncorrectSound();
       // 不正解時も問題と答えをセットで読み上げる
-      speakQuestionAndAnswer(currentQuestion.reading, currentQuestion.answerReading);
+      speakQuestionAndAnswer(
+        currentQuestion.reading,
+        currentQuestion.answerReading,
+      );
       // 不正解時に間違いノートに記録
       recordMistake(currentQuestion.questionKey);
     }
@@ -185,21 +202,22 @@ document.addEventListener("DOMContentLoaded", function () {
     displayRewardCalendar();
 
     questionDiv.textContent = `せいかいは ${correctAnswers}こ だったよ！`;
-    choiceButtons.forEach((button) => (button.style.display = "none"));
-    startButton.style.display = "inline-block";
+    choiceButtons.forEach((button) => (button.style.display = 'none'));
+    startButton.style.display = 'inline-block';
   }
 
-  startButton.addEventListener("click", function () {
+  startButton.addEventListener('click', function () {
     currentQuestionIndex = 0;
     correctAnswers = 0;
     gameStartTime = Date.now();
-    startButton.style.display = "none";
-    choiceButtons.forEach((button) => (button.style.display = "inline-block"));
+    startButton.style.display = 'none';
+    choiceButtons.forEach((button) => (button.style.display = 'inline-block'));
     displayQuestion();
     updateQuestionProgress(currentQuestionIndex);
   });
 
   const settings = loadSettings();
+  applySettingsToDOM(settings);
   totalQuestions = settings.questionCount;
   learningMode = settings.learningMode;
   gameHistory = loadHistory();
@@ -210,28 +228,30 @@ document.addEventListener("DOMContentLoaded", function () {
   displayCharacter(loadCharacterXP());
   displayRewardCalendar();
 
+  function persistSettingsFromDOM() {
+    const newSettings = readSettingsFromDOM();
+    saveSettings(newSettings);
+    totalQuestions = newSettings.questionCount;
+    learningMode = newSettings.learningMode;
+    return newSettings;
+  }
+
   document
     .querySelectorAll('#settings input[type="checkbox"]')
     .forEach((checkbox) => {
-      checkbox.addEventListener("change", () => {
-        const newSettings = saveSettings();
-        totalQuestions = newSettings.questionCount;
-        learningMode = newSettings.learningMode;
+      checkbox.addEventListener('change', () => {
+        persistSettingsFromDOM();
       });
     });
 
-  document.getElementById("questionCount").addEventListener("change", () => {
-    const newSettings = saveSettings();
-    totalQuestions = newSettings.questionCount;
-    learningMode = newSettings.learningMode;
+  document.getElementById('questionCount').addEventListener('change', () => {
+    persistSettingsFromDOM();
   });
 
-  const modeSelect = document.getElementById("learningMode");
+  const modeSelect = document.getElementById('learningMode');
   if (modeSelect) {
-    modeSelect.addEventListener("change", () => {
-      const newSettings = saveSettings();
-      totalQuestions = newSettings.questionCount;
-      learningMode = newSettings.learningMode;
+    modeSelect.addEventListener('change', () => {
+      persistSettingsFromDOM();
       updateModeDescription();
     });
   }

--- a/js/main.js
+++ b/js/main.js
@@ -1,11 +1,11 @@
-import { generateMultiplicationQuestion, generateChoices } from "./logic.js";
+import { generateMultiplicationQuestion, generateChoices } from './logic.js';
 import {
   speakQuestion,
   speakAnswer,
   speakQuestionAndAnswer,
   playCorrectSound,
   playIncorrectSound,
-} from "./audio.js";
+} from './audio.js';
 import {
   loadSettings,
   saveSettings,
@@ -17,7 +17,7 @@ import {
   loadCharacterXP,
   addCharacterXP,
   recordTodayStudy,
-} from "./storage.js";
+} from './storage.js';
 import {
   updateQuestionProgress,
   displayHistory,
@@ -25,38 +25,38 @@ import {
   displayCharacter,
   showLevelUpModal,
   displayRewardCalendar,
-} from "./ui.js";
-import { updateQuestionStats } from "./analytics.js";
+} from './ui.js';
+import { updateQuestionStats } from './analytics.js';
 import {
   updateModeDescription,
   applySettingsToDOM,
   readSettingsFromDOM,
-} from "./ui-helper.js";
+} from './ui-helper.js';
 import {
   updateAchievementStats,
   updateStreak,
   checkNewBadges,
   showBadgeModal,
-} from "./badges.js";
-import { displayBadgeCollection } from "./badge-display.js";
-import { updateAllCharts } from "./charts.js";
-import { MenuManager } from "./menu.js";
-import { calculateXP, hasLeveledUp, getCurrentLevel } from "./character.js";
+} from './badges.js';
+import { displayBadgeCollection } from './badge-display.js';
+import { updateAllCharts } from './charts.js';
+import { MenuManager } from './menu.js';
+import { calculateXP, hasLeveledUp, getCurrentLevel } from './character.js';
 
 // レベルアップモーダル表示の遅延時間（ミリ秒）
 const LEVEL_UP_MODAL_DELAY_MS = 2500;
 
 let totalQuestions = 10;
-let learningMode = "normal";
+let learningMode = 'normal';
 let selectedLevels = null;
 
-document.addEventListener("DOMContentLoaded", function () {
+document.addEventListener('DOMContentLoaded', function () {
   // メニューマネージャーを初期化
   const menuManager = new MenuManager();
 
-  const questionDiv = document.getElementById("question");
-  const choiceButtons = document.querySelectorAll(".choice-btn");
-  const startButton = document.getElementById("start-btn");
+  const questionDiv = document.getElementById('question');
+  const choiceButtons = document.querySelectorAll('.choice-btn');
+  const startButton = document.getElementById('start-btn');
 
   let currentQuestion;
   let currentQuestionIndex = 0;
@@ -77,7 +77,7 @@ document.addEventListener("DOMContentLoaded", function () {
     questionDiv.textContent = currentQuestion.question;
     displayChoices();
     choiceButtons.forEach((button) => {
-      button.style.backgroundColor = "#f0f0f0";
+      button.style.backgroundColor = '#f0f0f0';
       button.style.opacity = 1;
     });
     await speakQuestion(currentQuestion.reading);
@@ -108,7 +108,7 @@ document.addEventListener("DOMContentLoaded", function () {
     // 連続正解数を更新
     updateStreak(isCorrect);
 
-    correctAnswerButton.style.backgroundColor = "lightgreen";
+    correctAnswerButton.style.backgroundColor = 'lightgreen';
     if (isCorrect) {
       correctAnswers++;
       playCorrectSound();
@@ -136,7 +136,7 @@ document.addEventListener("DOMContentLoaded", function () {
       // キャラクター表示を更新
       displayCharacter(newXP);
     } else {
-      selectedButton.style.backgroundColor = "pink";
+      selectedButton.style.backgroundColor = 'pink';
       playIncorrectSound();
       // 不正解時も問題と答えをセットで読み上げる
       speakQuestionAndAnswer(
@@ -200,16 +200,16 @@ document.addEventListener("DOMContentLoaded", function () {
     displayRewardCalendar();
 
     questionDiv.textContent = `せいかいは ${correctAnswers}こ だったよ！`;
-    choiceButtons.forEach((button) => (button.style.display = "none"));
-    startButton.style.display = "inline-block";
+    choiceButtons.forEach((button) => (button.style.display = 'none'));
+    startButton.style.display = 'inline-block';
   }
 
-  startButton.addEventListener("click", function () {
+  startButton.addEventListener('click', function () {
     currentQuestionIndex = 0;
     correctAnswers = 0;
     gameStartTime = Date.now();
-    startButton.style.display = "none";
-    choiceButtons.forEach((button) => (button.style.display = "inline-block"));
+    startButton.style.display = 'none';
+    choiceButtons.forEach((button) => (button.style.display = 'inline-block'));
     displayQuestion();
     updateQuestionProgress(currentQuestionIndex);
   });
@@ -241,18 +241,21 @@ document.addEventListener("DOMContentLoaded", function () {
   document
     .querySelectorAll('#settings input[type="checkbox"]')
     .forEach((checkbox) => {
-      checkbox.addEventListener("change", () => {
+      checkbox.addEventListener('change', () => {
         persistSettingsFromDOM();
       });
     });
 
-  document.getElementById("questionCount").addEventListener("change", () => {
-    persistSettingsFromDOM();
-  });
+  const questionCountInput = document.getElementById('questionCount');
+  if (questionCountInput) {
+    questionCountInput.addEventListener('change', () => {
+      persistSettingsFromDOM();
+    });
+  }
 
-  const modeSelect = document.getElementById("learningMode");
+  const modeSelect = document.getElementById('learningMode');
   if (modeSelect) {
-    modeSelect.addEventListener("change", () => {
+    modeSelect.addEventListener('change', () => {
       persistSettingsFromDOM();
       updateModeDescription();
     });

--- a/js/storage.js
+++ b/js/storage.js
@@ -1,55 +1,43 @@
+/**
+ * @typedef {Object} Settings
+ * @property {number[]|null} selectedLevels - 選択中の段（null時はDOMに反映しない）
+ * @property {number} questionCount - 出題数
+ * @property {string} learningMode - 学習モード ("normal" | "weak" | "adaptive")
+ */
+
+/**
+ * 設定をlocalStorageから読み込む（純粋なデータ取得関数）
+ * @returns {Settings}
+ */
 export function loadSettings() {
-  const storedLevels = localStorage.getItem("selectedLevels");
-  if (storedLevels) {
-    const selectedLevels = JSON.parse(storedLevels);
-    document
-      .querySelectorAll('#settings input[type="checkbox"]')
-      .forEach((checkbox) => {
-        checkbox.checked = selectedLevels.includes(parseInt(checkbox.value));
-      });
-  }
-
-  const storedQuestionCount = localStorage.getItem("questionCount");
-  if (storedQuestionCount) {
-    document.getElementById("questionCount").value = storedQuestionCount;
-  }
-
-  const storedMode = localStorage.getItem("learningMode");
-  if (storedMode) {
-    const modeSelect = document.getElementById("learningMode");
-    if (modeSelect) {
-      modeSelect.value = storedMode;
-    }
-  }
+  const storedLevels = localStorage.getItem('selectedLevels');
+  const storedQuestionCount = localStorage.getItem('questionCount');
+  const storedMode = localStorage.getItem('learningMode');
 
   return {
+    selectedLevels: storedLevels ? JSON.parse(storedLevels) : null,
     questionCount: storedQuestionCount ? parseInt(storedQuestionCount) : 10,
-    learningMode: storedMode || "normal",
+    learningMode: storedMode || 'normal',
   };
 }
 
-export function saveSettings() {
-  const selectedLevels = Array.from(
-    document.querySelectorAll('#settings input[type="checkbox"]:checked'),
-  ).map((checkbox) => parseInt(checkbox.value));
-  localStorage.setItem("selectedLevels", JSON.stringify(selectedLevels));
-
-  const questionCount = document.getElementById("questionCount").value;
-  localStorage.setItem("questionCount", questionCount);
-
-  const modeSelect = document.getElementById("learningMode");
-  if (modeSelect) {
-    localStorage.setItem("learningMode", modeSelect.value);
+/**
+ * 設定をlocalStorageへ保存する（純粋なデータ保存関数）
+ * @param {Settings} settings
+ */
+export function saveSettings(settings) {
+  if (settings.selectedLevels) {
+    localStorage.setItem(
+      'selectedLevels',
+      JSON.stringify(settings.selectedLevels),
+    );
   }
-
-  return {
-    questionCount: parseInt(questionCount),
-    learningMode: modeSelect ? modeSelect.value : "normal",
-  };
+  localStorage.setItem('questionCount', String(settings.questionCount));
+  localStorage.setItem('learningMode', settings.learningMode);
 }
 
 export function loadHistory() {
-  const storedHistory = localStorage.getItem("gameHistory");
+  const storedHistory = localStorage.getItem('gameHistory');
   if (storedHistory) {
     try {
       return JSON.parse(storedHistory);
@@ -61,7 +49,7 @@ export function loadHistory() {
 }
 
 export function saveHistory(gameHistory) {
-  localStorage.setItem("gameHistory", JSON.stringify(gameHistory));
+  localStorage.setItem('gameHistory', JSON.stringify(gameHistory));
 }
 
 /**
@@ -69,7 +57,7 @@ export function saveHistory(gameHistory) {
  * @returns {Array<{questionKey: string, consecutiveCorrect: number}>}
  */
 export function loadMistakes() {
-  const storedMistakes = localStorage.getItem("mistakes");
+  const storedMistakes = localStorage.getItem('mistakes');
   if (storedMistakes) {
     try {
       return JSON.parse(storedMistakes);
@@ -85,7 +73,7 @@ export function loadMistakes() {
  * @param {Array<{questionKey: string, consecutiveCorrect: number}>} mistakes
  */
 export function saveMistakes(mistakes) {
-  localStorage.setItem("mistakes", JSON.stringify(mistakes));
+  localStorage.setItem('mistakes', JSON.stringify(mistakes));
 }
 
 /**
@@ -135,7 +123,7 @@ export function updateCorrectStreak(questionKey) {
  * @returns {number} 現在のXP
  */
 export function loadCharacterXP() {
-  const storedXP = localStorage.getItem("characterXP");
+  const storedXP = localStorage.getItem('characterXP');
   return storedXP ? parseInt(storedXP) : 0;
 }
 
@@ -144,7 +132,7 @@ export function loadCharacterXP() {
  * @param {number} xp - 新しいXP
  */
 export function saveCharacterXP(xp) {
-  localStorage.setItem("characterXP", xp.toString());
+  localStorage.setItem('characterXP', xp.toString());
 }
 
 /**
@@ -164,7 +152,7 @@ export function addCharacterXP(amount) {
  * @returns {Object} 日付をキー、学習回数を値とするオブジェクト
  */
 export function loadCalendar() {
-  const storedCalendar = localStorage.getItem("learningCalendar");
+  const storedCalendar = localStorage.getItem('learningCalendar');
   if (storedCalendar) {
     try {
       return JSON.parse(storedCalendar);
@@ -180,7 +168,7 @@ export function loadCalendar() {
  * @param {Object} calendar - 日付をキー、学習回数を値とするオブジェクト
  */
 export function saveCalendar(calendar) {
-  localStorage.setItem("learningCalendar", JSON.stringify(calendar));
+  localStorage.setItem('learningCalendar', JSON.stringify(calendar));
 }
 
 /**
@@ -190,8 +178,8 @@ export function saveCalendar(calendar) {
  */
 function formatDateKey(date) {
   const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
   return `${year}-${month}-${day}`;
 }
 

--- a/js/storage.js
+++ b/js/storage.js
@@ -10,9 +10,9 @@
  * @returns {Settings}
  */
 export function loadSettings() {
-  const storedLevels = localStorage.getItem("selectedLevels");
-  const storedQuestionCount = localStorage.getItem("questionCount");
-  const storedMode = localStorage.getItem("learningMode");
+  const storedLevels = localStorage.getItem('selectedLevels');
+  const storedQuestionCount = localStorage.getItem('questionCount');
+  const storedMode = localStorage.getItem('learningMode');
 
   let selectedLevels = null;
   if (storedLevels) {
@@ -24,7 +24,7 @@ export function loadSettings() {
     }
   }
 
-  const parsedQuestionCount = Number.parseInt(storedQuestionCount ?? "", 10);
+  const parsedQuestionCount = Number.parseInt(storedQuestionCount ?? '', 10);
   const questionCount =
     Number.isFinite(parsedQuestionCount) && parsedQuestionCount > 0
       ? parsedQuestionCount
@@ -33,7 +33,7 @@ export function loadSettings() {
   return {
     selectedLevels,
     questionCount,
-    learningMode: storedMode || "normal",
+    learningMode: storedMode || 'normal',
   };
 }
 
@@ -44,16 +44,18 @@ export function loadSettings() {
 export function saveSettings(settings) {
   if (settings.selectedLevels) {
     localStorage.setItem(
-      "selectedLevels",
+      'selectedLevels',
       JSON.stringify(settings.selectedLevels),
     );
+  } else if (settings.selectedLevels === null) {
+    localStorage.removeItem('selectedLevels');
   }
-  localStorage.setItem("questionCount", String(settings.questionCount));
-  localStorage.setItem("learningMode", settings.learningMode);
+  localStorage.setItem('questionCount', String(settings.questionCount));
+  localStorage.setItem('learningMode', settings.learningMode);
 }
 
 export function loadHistory() {
-  const storedHistory = localStorage.getItem("gameHistory");
+  const storedHistory = localStorage.getItem('gameHistory');
   if (storedHistory) {
     try {
       return JSON.parse(storedHistory);
@@ -65,7 +67,7 @@ export function loadHistory() {
 }
 
 export function saveHistory(gameHistory) {
-  localStorage.setItem("gameHistory", JSON.stringify(gameHistory));
+  localStorage.setItem('gameHistory', JSON.stringify(gameHistory));
 }
 
 /**
@@ -73,7 +75,7 @@ export function saveHistory(gameHistory) {
  * @returns {Array<{questionKey: string, consecutiveCorrect: number}>}
  */
 export function loadMistakes() {
-  const storedMistakes = localStorage.getItem("mistakes");
+  const storedMistakes = localStorage.getItem('mistakes');
   if (storedMistakes) {
     try {
       return JSON.parse(storedMistakes);
@@ -89,7 +91,7 @@ export function loadMistakes() {
  * @param {Array<{questionKey: string, consecutiveCorrect: number}>} mistakes
  */
 export function saveMistakes(mistakes) {
-  localStorage.setItem("mistakes", JSON.stringify(mistakes));
+  localStorage.setItem('mistakes', JSON.stringify(mistakes));
 }
 
 /**
@@ -139,7 +141,7 @@ export function updateCorrectStreak(questionKey) {
  * @returns {number} 現在のXP
  */
 export function loadCharacterXP() {
-  const storedXP = localStorage.getItem("characterXP");
+  const storedXP = localStorage.getItem('characterXP');
   return storedXP ? parseInt(storedXP) : 0;
 }
 
@@ -148,7 +150,7 @@ export function loadCharacterXP() {
  * @param {number} xp - 新しいXP
  */
 export function saveCharacterXP(xp) {
-  localStorage.setItem("characterXP", xp.toString());
+  localStorage.setItem('characterXP', xp.toString());
 }
 
 /**
@@ -168,7 +170,7 @@ export function addCharacterXP(amount) {
  * @returns {Object} 日付をキー、学習回数を値とするオブジェクト
  */
 export function loadCalendar() {
-  const storedCalendar = localStorage.getItem("learningCalendar");
+  const storedCalendar = localStorage.getItem('learningCalendar');
   if (storedCalendar) {
     try {
       return JSON.parse(storedCalendar);
@@ -184,7 +186,7 @@ export function loadCalendar() {
  * @param {Object} calendar - 日付をキー、学習回数を値とするオブジェクト
  */
 export function saveCalendar(calendar) {
-  localStorage.setItem("learningCalendar", JSON.stringify(calendar));
+  localStorage.setItem('learningCalendar', JSON.stringify(calendar));
 }
 
 /**
@@ -194,8 +196,8 @@ export function saveCalendar(calendar) {
  */
 function formatDateKey(date) {
   const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
   return `${year}-${month}-${day}`;
 }
 

--- a/js/storage.js
+++ b/js/storage.js
@@ -10,14 +10,30 @@
  * @returns {Settings}
  */
 export function loadSettings() {
-  const storedLevels = localStorage.getItem('selectedLevels');
-  const storedQuestionCount = localStorage.getItem('questionCount');
-  const storedMode = localStorage.getItem('learningMode');
+  const storedLevels = localStorage.getItem("selectedLevels");
+  const storedQuestionCount = localStorage.getItem("questionCount");
+  const storedMode = localStorage.getItem("learningMode");
+
+  let selectedLevels = null;
+  if (storedLevels) {
+    try {
+      const parsed = JSON.parse(storedLevels);
+      selectedLevels = Array.isArray(parsed) ? parsed : null;
+    } catch (e) {
+      selectedLevels = null;
+    }
+  }
+
+  const parsedQuestionCount = Number.parseInt(storedQuestionCount ?? "", 10);
+  const questionCount =
+    Number.isFinite(parsedQuestionCount) && parsedQuestionCount > 0
+      ? parsedQuestionCount
+      : 10;
 
   return {
-    selectedLevels: storedLevels ? JSON.parse(storedLevels) : null,
-    questionCount: storedQuestionCount ? parseInt(storedQuestionCount) : 10,
-    learningMode: storedMode || 'normal',
+    selectedLevels,
+    questionCount,
+    learningMode: storedMode || "normal",
   };
 }
 
@@ -28,16 +44,16 @@ export function loadSettings() {
 export function saveSettings(settings) {
   if (settings.selectedLevels) {
     localStorage.setItem(
-      'selectedLevels',
+      "selectedLevels",
       JSON.stringify(settings.selectedLevels),
     );
   }
-  localStorage.setItem('questionCount', String(settings.questionCount));
-  localStorage.setItem('learningMode', settings.learningMode);
+  localStorage.setItem("questionCount", String(settings.questionCount));
+  localStorage.setItem("learningMode", settings.learningMode);
 }
 
 export function loadHistory() {
-  const storedHistory = localStorage.getItem('gameHistory');
+  const storedHistory = localStorage.getItem("gameHistory");
   if (storedHistory) {
     try {
       return JSON.parse(storedHistory);
@@ -49,7 +65,7 @@ export function loadHistory() {
 }
 
 export function saveHistory(gameHistory) {
-  localStorage.setItem('gameHistory', JSON.stringify(gameHistory));
+  localStorage.setItem("gameHistory", JSON.stringify(gameHistory));
 }
 
 /**
@@ -57,7 +73,7 @@ export function saveHistory(gameHistory) {
  * @returns {Array<{questionKey: string, consecutiveCorrect: number}>}
  */
 export function loadMistakes() {
-  const storedMistakes = localStorage.getItem('mistakes');
+  const storedMistakes = localStorage.getItem("mistakes");
   if (storedMistakes) {
     try {
       return JSON.parse(storedMistakes);
@@ -73,7 +89,7 @@ export function loadMistakes() {
  * @param {Array<{questionKey: string, consecutiveCorrect: number}>} mistakes
  */
 export function saveMistakes(mistakes) {
-  localStorage.setItem('mistakes', JSON.stringify(mistakes));
+  localStorage.setItem("mistakes", JSON.stringify(mistakes));
 }
 
 /**
@@ -123,7 +139,7 @@ export function updateCorrectStreak(questionKey) {
  * @returns {number} 現在のXP
  */
 export function loadCharacterXP() {
-  const storedXP = localStorage.getItem('characterXP');
+  const storedXP = localStorage.getItem("characterXP");
   return storedXP ? parseInt(storedXP) : 0;
 }
 
@@ -132,7 +148,7 @@ export function loadCharacterXP() {
  * @param {number} xp - 新しいXP
  */
 export function saveCharacterXP(xp) {
-  localStorage.setItem('characterXP', xp.toString());
+  localStorage.setItem("characterXP", xp.toString());
 }
 
 /**
@@ -152,7 +168,7 @@ export function addCharacterXP(amount) {
  * @returns {Object} 日付をキー、学習回数を値とするオブジェクト
  */
 export function loadCalendar() {
-  const storedCalendar = localStorage.getItem('learningCalendar');
+  const storedCalendar = localStorage.getItem("learningCalendar");
   if (storedCalendar) {
     try {
       return JSON.parse(storedCalendar);
@@ -168,7 +184,7 @@ export function loadCalendar() {
  * @param {Object} calendar - 日付をキー、学習回数を値とするオブジェクト
  */
 export function saveCalendar(calendar) {
-  localStorage.setItem('learningCalendar', JSON.stringify(calendar));
+  localStorage.setItem("learningCalendar", JSON.stringify(calendar));
 }
 
 /**
@@ -178,8 +194,8 @@ export function saveCalendar(calendar) {
  */
 function formatDateKey(date) {
   const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
 }
 

--- a/js/ui-helper.js
+++ b/js/ui-helper.js
@@ -3,21 +3,21 @@
  */
 
 const MODE_DESCRIPTIONS = {
-  normal: 'いろいろなもんだいがでるよ',
-  weak: 'にがてなもんだいをたくさんれんしゅうするよ',
-  adaptive: 'きみにぴったりのもんだいがでるよ',
+  normal: "いろいろなもんだいがでるよ",
+  weak: "にがてなもんだいをたくさんれんしゅうするよ",
+  adaptive: "きみにぴったりのもんだいがでるよ",
 };
 
 /**
  * 学習モードの説明文を更新
  */
 export function updateModeDescription() {
-  const modeSelect = document.getElementById('learningMode');
-  const descriptionSpan = document.getElementById('modeDescription');
+  const modeSelect = document.getElementById("learningMode");
+  const descriptionSpan = document.getElementById("modeDescription");
 
   if (modeSelect && descriptionSpan) {
     const selectedMode = modeSelect.value;
-    descriptionSpan.textContent = MODE_DESCRIPTIONS[selectedMode] || '';
+    descriptionSpan.textContent = MODE_DESCRIPTIONS[selectedMode] || "";
   }
 }
 
@@ -36,12 +36,12 @@ export function applySettingsToDOM(settings) {
       });
   }
 
-  const questionCountInput = document.getElementById('questionCount');
+  const questionCountInput = document.getElementById("questionCount");
   if (questionCountInput) {
     questionCountInput.value = String(settings.questionCount);
   }
 
-  const modeSelect = document.getElementById('learningMode');
+  const modeSelect = document.getElementById("learningMode");
   if (modeSelect) {
     modeSelect.value = settings.learningMode;
   }
@@ -56,13 +56,18 @@ export function readSettingsFromDOM() {
     document.querySelectorAll('#settings input[type="checkbox"]:checked'),
   ).map((checkbox) => parseInt(checkbox.value));
 
-  const questionCountInput = document.getElementById('questionCount');
-  const questionCount = questionCountInput
-    ? parseInt(questionCountInput.value)
-    : 10;
+  const questionCountInput = document.getElementById("questionCount");
+  const parsedQuestionCount = Number.parseInt(
+    questionCountInput?.value ?? "",
+    10,
+  );
+  const questionCount =
+    Number.isFinite(parsedQuestionCount) && parsedQuestionCount > 0
+      ? parsedQuestionCount
+      : 10;
 
-  const modeSelect = document.getElementById('learningMode');
-  const learningMode = modeSelect ? modeSelect.value : 'normal';
+  const modeSelect = document.getElementById("learningMode");
+  const learningMode = modeSelect ? modeSelect.value : "normal";
 
   return { selectedLevels, questionCount, learningMode };
 }

--- a/js/ui-helper.js
+++ b/js/ui-helper.js
@@ -3,20 +3,66 @@
  */
 
 const MODE_DESCRIPTIONS = {
-  normal: "いろいろなもんだいがでるよ",
-  weak: "にがてなもんだいをたくさんれんしゅうするよ",
-  adaptive: "きみにぴったりのもんだいがでるよ",
+  normal: 'いろいろなもんだいがでるよ',
+  weak: 'にがてなもんだいをたくさんれんしゅうするよ',
+  adaptive: 'きみにぴったりのもんだいがでるよ',
 };
 
 /**
  * 学習モードの説明文を更新
  */
 export function updateModeDescription() {
-  const modeSelect = document.getElementById("learningMode");
-  const descriptionSpan = document.getElementById("modeDescription");
+  const modeSelect = document.getElementById('learningMode');
+  const descriptionSpan = document.getElementById('modeDescription');
 
   if (modeSelect && descriptionSpan) {
     const selectedMode = modeSelect.value;
-    descriptionSpan.textContent = MODE_DESCRIPTIONS[selectedMode] || "";
+    descriptionSpan.textContent = MODE_DESCRIPTIONS[selectedMode] || '';
   }
+}
+
+/**
+ * 設定オブジェクトをDOMへ反映する
+ * @param {import('./storage.js').Settings} settings
+ */
+export function applySettingsToDOM(settings) {
+  if (settings.selectedLevels) {
+    document
+      .querySelectorAll('#settings input[type="checkbox"]')
+      .forEach((checkbox) => {
+        checkbox.checked = settings.selectedLevels.includes(
+          parseInt(checkbox.value),
+        );
+      });
+  }
+
+  const questionCountInput = document.getElementById('questionCount');
+  if (questionCountInput) {
+    questionCountInput.value = String(settings.questionCount);
+  }
+
+  const modeSelect = document.getElementById('learningMode');
+  if (modeSelect) {
+    modeSelect.value = settings.learningMode;
+  }
+}
+
+/**
+ * DOMから設定オブジェクトを読み取る
+ * @returns {import('./storage.js').Settings}
+ */
+export function readSettingsFromDOM() {
+  const selectedLevels = Array.from(
+    document.querySelectorAll('#settings input[type="checkbox"]:checked'),
+  ).map((checkbox) => parseInt(checkbox.value));
+
+  const questionCountInput = document.getElementById('questionCount');
+  const questionCount = questionCountInput
+    ? parseInt(questionCountInput.value)
+    : 10;
+
+  const modeSelect = document.getElementById('learningMode');
+  const learningMode = modeSelect ? modeSelect.value : 'normal';
+
+  return { selectedLevels, questionCount, learningMode };
 }


### PR DESCRIPTION
Closes #5

## Summary

- `js/storage.js` の `loadSettings`/`saveSettings` を **localStorage 操作のみを行う純粋関数** にリファクタ
- DOM 操作を **`js/ui-helper.js`** の `applySettingsToDOM` / `readSettingsFromDOM` に分離
- `js/main.js` を新APIに置換し、設定永続化を `persistSettingsFromDOM()` ヘルパーへ集約

## 変更内容

### `js/storage.js`
- `@typedef Settings` を新設（`selectedLevels` / `questionCount` / `learningMode`）
- `loadSettings()`: localStorage から Settings オブジェクトを返すのみ（DOM操作なし）
- `saveSettings(settings)`: 引数 Settings を localStorage に保存するのみ（DOM操作なし）
- 戻り値に `selectedLevels` を含めることで設定全体を一貫表現

### `js/ui-helper.js`
- `applySettingsToDOM(settings)`: Settings を DOM に反映（nullガード付き）
- `readSettingsFromDOM()`: DOM から Settings を読み取って返す

### `js/main.js`
- 起動時: `loadSettings()` → `applySettingsToDOM(settings)` の順
- 変更ハンドラ: `readSettingsFromDOM()` → `saveSettings(settings)` の順
- 3 箇所のイベントハンドラを `persistSettingsFromDOM()` で共通化

## 後方互換性

- localStorage キー (`selectedLevels` / `questionCount` / `learningMode`) は不変
- 既存ユーザーの保存済み設定はそのまま有効

## 補足

- ファイルは PostToolUse フォーマッタによりクォート等が整形されている。本質的な変更は上記のみ。
- `npm run lint` 通過済み
- テスト追加は本プロジェクトにテストフレームワークが未導入のため、本PRの対象外（必要なら別Issueで起票）

## Test plan

- [ ] アプリ起動時に設定UI（段のチェックボックス／問題数／学習モード）が前回値で復元される
- [ ] チェックボックス変更時に localStorage が更新される
- [ ] 問題数の input 変更時に localStorage が更新される
- [ ] 学習モードのセレクト変更時に localStorage が更新され、説明文も更新される
- [ ] ページリロード後も設定が保持されている
- [ ] `learningMode` セレクト要素が存在しない状態でもエラーにならない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 設定の読み取り・保存・UI反映を分離・整理し、起動時に保存設定を読み込んで画面へ自動適用するようにしました。選択レベルの扱いを明確化し、問題生成の一貫性を向上させました。
* **改善**
  * 設定変更が即座に保存・反映され、無効な入力は既定値へフォールバックするようになりました。要素未存在時の安全な動作を強化しました。
* **Style**
  * 問題の読み上げ表現を整え、表示と音声の整合性を改善しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/kakezan-manabo/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->