### PR TITLE
refactor: 💡 displayRewardCalendar関数を責務別に分割

### DIFF
--- a/js/calendar-renderer.js
+++ b/js/calendar-renderer.js
@@ -80,8 +80,9 @@ export function createCalendarGrid(date, calendarData, today = new Date()) {
     gridDiv.appendChild(emptyCell);
   }
 
-  // 各日付のセルを追加
-  for (let day = 1; day <= lastDay.getDate(); day++) {
+  // 各日付のセルを追加（getDate() の呼び出しはループ外に抽出）
+  const daysInMonth = lastDay.getDate();
+  for (let day = 1; day <= daysInMonth; day++) {
     gridDiv.appendChild(createDayCell(year, month, day, calendarData, today));
   }
 

--- a/js/calendar-renderer.js
+++ b/js/calendar-renderer.js
@@ -1,0 +1,146 @@
+/**
+ * ごほうびカレンダーのDOM生成を担うレンダラー。
+ * 各ヘルパーはDOM要素を生成して返すのみで、外側のコンテナへの挿入は呼び出し元の責務。
+ */
+
+const WEEKDAY_LABELS = ['にち', 'げつ', 'か', 'すい', 'もく', 'きん', 'ど'];
+
+/**
+ * 連続学習日数の表示要素を生成
+ * @param {number} streak - 連続学習日数
+ * @returns {HTMLElement}
+ */
+export function createStreakElement(streak) {
+  const streakDiv = document.createElement('div');
+  streakDiv.classList.add('calendar-streak');
+
+  const emojiSpan = document.createElement('span');
+  emojiSpan.className = 'streak-emoji';
+  emojiSpan.textContent = '🔥';
+
+  const numberSpan = document.createElement('span');
+  numberSpan.className = 'streak-number';
+  numberSpan.textContent = streak;
+
+  streakDiv.append(emojiSpan, ' ', numberSpan, ' にちれんぞく！');
+  return streakDiv;
+}
+
+/**
+ * 年月ヘッダー要素を生成
+ * @param {Date} date - 対象月の任意の日付
+ * @returns {HTMLElement}
+ */
+export function createCalendarHeader(date) {
+  const headerDiv = document.createElement('div');
+  headerDiv.classList.add('calendar-header');
+  headerDiv.textContent = `${date.getFullYear()}ねん ${date.getMonth() + 1}がつ`;
+  return headerDiv;
+}
+
+/**
+ * 曜日ヘッダー要素を生成
+ * @returns {HTMLElement}
+ */
+export function createWeekdaysElement() {
+  const weekdaysDiv = document.createElement('div');
+  weekdaysDiv.classList.add('calendar-weekdays');
+
+  WEEKDAY_LABELS.forEach((day) => {
+    const dayDiv = document.createElement('div');
+    dayDiv.classList.add('calendar-weekday');
+    dayDiv.textContent = day;
+    weekdaysDiv.appendChild(dayDiv);
+  });
+
+  return weekdaysDiv;
+}
+
+/**
+ * 日付グリッド要素を生成
+ * @param {Date} date - 対象月の任意の日付（年月の決定に使用）
+ * @param {Object} calendarData - 日付キー(YYYY-MM-DD) -> 学習回数のマップ
+ * @param {Date} [today=new Date()] - 今日として扱う日付（テスト用に注入可能）
+ * @returns {HTMLElement}
+ */
+export function createCalendarGrid(date, calendarData, today = new Date()) {
+  const gridDiv = document.createElement('div');
+  gridDiv.classList.add('calendar-grid');
+
+  const year = date.getFullYear();
+  const month = date.getMonth();
+  const firstDay = new Date(year, month, 1);
+  const lastDay = new Date(year, month + 1, 0);
+
+  // 月初の曜日まで空セルを追加
+  const firstDayOfWeek = firstDay.getDay();
+  for (let i = 0; i < firstDayOfWeek; i++) {
+    const emptyCell = document.createElement('div');
+    emptyCell.classList.add('calendar-day', 'calendar-day-empty');
+    gridDiv.appendChild(emptyCell);
+  }
+
+  // 各日付のセルを追加
+  for (let day = 1; day <= lastDay.getDate(); day++) {
+    gridDiv.appendChild(createDayCell(year, month, day, calendarData, today));
+  }
+
+  return gridDiv;
+}
+
+/**
+ * 1日分のセル要素を生成（内部利用）
+ * @param {number} year
+ * @param {number} month - 0始まり
+ * @param {number} day
+ * @param {Object} calendarData
+ * @param {Date} today
+ * @returns {HTMLElement}
+ */
+function createDayCell(year, month, day, calendarData, today) {
+  const dayCell = document.createElement('div');
+  dayCell.classList.add('calendar-day');
+
+  const dateKey = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+  const studyCount = calendarData[dateKey] || 0;
+
+  const dateNumber = document.createElement('div');
+  dateNumber.classList.add('calendar-day-number');
+  dateNumber.textContent = day;
+  dayCell.appendChild(dateNumber);
+
+  if (studyCount > 0) {
+    const stamp = document.createElement('div');
+    stamp.classList.add('calendar-stamp');
+    stamp.textContent = '⭐';
+    dayCell.appendChild(stamp);
+    dayCell.classList.add('calendar-day-studied');
+  }
+
+  if (
+    day === today.getDate() &&
+    month === today.getMonth() &&
+    year === today.getFullYear()
+  ) {
+    dayCell.classList.add('calendar-day-today');
+  }
+
+  return dayCell;
+}
+
+/**
+ * カレンダー全体（連続日数 + ヘッダー + 曜日 + グリッド）を組み立てて返す
+ * @param {Date} date - 対象月の任意の日付
+ * @param {Object} calendarData
+ * @param {number} streak
+ * @param {Date} [today=new Date()]
+ * @returns {DocumentFragment}
+ */
+export function renderCalendar(date, calendarData, streak, today = new Date()) {
+  const fragment = document.createDocumentFragment();
+  fragment.appendChild(createStreakElement(streak));
+  fragment.appendChild(createCalendarHeader(date));
+  fragment.appendChild(createWeekdaysElement());
+  fragment.appendChild(createCalendarGrid(date, calendarData, today));
+  return fragment;
+}

--- a/js/calendar-renderer.js
+++ b/js/calendar-renderer.js
@@ -3,6 +3,8 @@
  * 各ヘルパーはDOM要素を生成して返すのみで、外側のコンテナへの挿入は呼び出し元の責務。
  */
 
+import { formatDateKey } from './storage.js';
+
 const WEEKDAY_LABELS = ['にち', 'げつ', 'か', 'すい', 'もく', 'きん', 'ど'];
 
 /**
@@ -102,7 +104,7 @@ function createDayCell(year, month, day, calendarData, today) {
   const dayCell = document.createElement('div');
   dayCell.classList.add('calendar-day');
 
-  const dateKey = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+  const dateKey = formatDateKey(new Date(year, month, day));
   const studyCount = calendarData[dateKey] || 0;
 
   const dateNumber = document.createElement('div');

--- a/js/storage.js
+++ b/js/storage.js
@@ -194,7 +194,7 @@ export function saveCalendar(calendar) {
  * @param {Date} date - 日付オブジェクト
  * @returns {string} YYYY-MM-DD形式の日付キー
  */
-function formatDateKey(date) {
+export function formatDateKey(date) {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, '0');
   const day = String(date.getDate()).padStart(2, '0');

--- a/js/ui.js
+++ b/js/ui.js
@@ -35,14 +35,12 @@ export function displayHistory(gameHistory) {
   filteredHistory.forEach((result) => {
     const row = document.createElement('tr');
 
-    const formattedDate = new Date(result.date)
-      .toLocaleString('ja-JP', {
-        month: '2-digit',
-        day: '2-digit',
-        hour: '2-digit',
-        minute: '2-digit',
-      })
-      .replace(/\//g, '/');
+    const formattedDate = new Date(result.date).toLocaleString('ja-JP', {
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
     const dateCell = document.createElement('td');
     dateCell.textContent = formattedDate;
     row.appendChild(dateCell);

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,14 +1,15 @@
-import { getCurrentLevel, getProgressToNextLevel } from "./character.js";
-import { loadCalendar, getCurrentStreak } from "./storage.js";
+import { getCurrentLevel, getProgressToNextLevel } from './character.js';
+import { loadCalendar, getCurrentStreak } from './storage.js';
+import { renderCalendar } from './calendar-renderer.js';
 
 export function updateQuestionProgress(currentQuestionIndex) {
-  const scoreDiv = document.getElementById("score");
+  const scoreDiv = document.getElementById('score');
   scoreDiv.textContent = `${currentQuestionIndex + 1} もんめ`;
 }
 
 export function displayHistory(gameHistory) {
-  const historyDiv = document.getElementById("history");
-  historyDiv.innerHTML = "";
+  const historyDiv = document.getElementById('history');
+  historyDiv.innerHTML = '';
   const filteredHistory = gameHistory
     .filter((result) => result.date !== undefined)
     .sort((a, b) => {
@@ -16,41 +17,41 @@ export function displayHistory(gameHistory) {
     });
 
   if (filteredHistory.length === 0) {
-    historyDiv.textContent = "まだきろくがないよ。これからがんばろう！";
+    historyDiv.textContent = 'まだきろくがないよ。これからがんばろう！';
     return;
   }
 
-  const table = document.createElement("table");
-  table.classList.add("history-table");
-  const headerRow = document.createElement("tr");
-  const headers = ["ひづけ", "せいかい", "もんだい"];
+  const table = document.createElement('table');
+  table.classList.add('history-table');
+  const headerRow = document.createElement('tr');
+  const headers = ['ひづけ', 'せいかい', 'もんだい'];
   headers.forEach((headerText) => {
-    const header = document.createElement("th");
+    const header = document.createElement('th');
     header.textContent = headerText;
     headerRow.appendChild(header);
   });
   table.appendChild(headerRow);
 
   filteredHistory.forEach((result) => {
-    const row = document.createElement("tr");
+    const row = document.createElement('tr');
 
     const formattedDate = new Date(result.date)
-      .toLocaleString("ja-JP", {
-        month: "2-digit",
-        day: "2-digit",
-        hour: "2-digit",
-        minute: "2-digit",
+      .toLocaleString('ja-JP', {
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
       })
-      .replace(/\//g, "/");
-    const dateCell = document.createElement("td");
+      .replace(/\//g, '/');
+    const dateCell = document.createElement('td');
     dateCell.textContent = formattedDate;
     row.appendChild(dateCell);
 
-    const correctAnswersCell = document.createElement("td");
-    correctAnswersCell.textContent = `${result.correctAnswers === result.totalQuestions ? "🥇" : result.correctAnswers === result.totalQuestions - 1 ? "🥈" : ""}${result.correctAnswers}`;
+    const correctAnswersCell = document.createElement('td');
+    correctAnswersCell.textContent = `${result.correctAnswers === result.totalQuestions ? '🥇' : result.correctAnswers === result.totalQuestions - 1 ? '🥈' : ''}${result.correctAnswers}`;
     row.appendChild(correctAnswersCell);
 
-    const totalQuestionsCell = document.createElement("td");
+    const totalQuestionsCell = document.createElement('td');
     totalQuestionsCell.textContent = result.totalQuestions;
     row.appendChild(totalQuestionsCell);
 
@@ -58,8 +59,8 @@ export function displayHistory(gameHistory) {
   });
 
   // テーブルをラッパーで囲む（モバイル対応）
-  const wrapper = document.createElement("div");
-  wrapper.classList.add("history-table-wrapper");
+  const wrapper = document.createElement('div');
+  wrapper.classList.add('history-table-wrapper');
   wrapper.appendChild(table);
   historyDiv.appendChild(wrapper);
 }
@@ -69,40 +70,42 @@ export function displayHistory(gameHistory) {
  * @param {Array<{questionKey: string, consecutiveCorrect: number}>} mistakes
  */
 export function displayMistakeNotebook(mistakes) {
-  const notebookDiv = document.getElementById("mistake-notebook");
+  const notebookDiv = document.getElementById('mistake-notebook');
   if (!notebookDiv) {
     return;
   }
 
-  notebookDiv.innerHTML = "";
+  notebookDiv.innerHTML = '';
 
   if (mistakes.length === 0) {
-    notebookDiv.textContent = "まだまちがえたもんだいはないよ。すごいね！";
+    notebookDiv.textContent = 'まだまちがえたもんだいはないよ。すごいね！';
     return;
   }
 
-  const container = document.createElement("div");
-  container.classList.add("mistake-cards");
+  const container = document.createElement('div');
+  container.classList.add('mistake-cards');
 
   mistakes.forEach((mistake) => {
-    const card = document.createElement("div");
-    card.classList.add("mistake-card");
+    const card = document.createElement('div');
+    card.classList.add('mistake-card');
 
-    const questionText = document.createElement("div");
-    questionText.classList.add("mistake-question");
-    const parts = mistake.questionKey.split("x");
+    const questionText = document.createElement('div');
+    questionText.classList.add('mistake-question');
+    const parts = mistake.questionKey.split('x');
     questionText.textContent = `${parts[0]} × ${parts[1]}`;
     card.appendChild(questionText);
 
-    const progress = document.createElement("div");
-    progress.classList.add("mistake-progress");
-    const stars = "⭐".repeat(mistake.consecutiveCorrect) + "☆".repeat(3 - mistake.consecutiveCorrect);
+    const progress = document.createElement('div');
+    progress.classList.add('mistake-progress');
+    const stars =
+      '⭐'.repeat(mistake.consecutiveCorrect) +
+      '☆'.repeat(3 - mistake.consecutiveCorrect);
     progress.textContent = `れんぞくせいかい: ${stars}`;
     card.appendChild(progress);
 
-    const helpText = document.createElement("div");
-    helpText.classList.add("mistake-help");
-    helpText.textContent = "3かいつづけてせいかいすると、クリアだよ！";
+    const helpText = document.createElement('div');
+    helpText.classList.add('mistake-help');
+    helpText.textContent = '3かいつづけてせいかいすると、クリアだよ！';
     card.appendChild(helpText);
 
     container.appendChild(card);
@@ -116,7 +119,7 @@ export function displayMistakeNotebook(mistakes) {
  * @param {number} xp - 現在のXP
  */
 export function displayCharacter(xp) {
-  const characterDiv = document.getElementById("character");
+  const characterDiv = document.getElementById('character');
   if (!characterDiv) {
     return;
   }
@@ -124,49 +127,49 @@ export function displayCharacter(xp) {
   const currentLevel = getCurrentLevel(xp);
   const progress = getProgressToNextLevel(xp);
 
-  characterDiv.innerHTML = "";
+  characterDiv.innerHTML = '';
 
-  const container = document.createElement("div");
-  container.classList.add("character-container");
+  const container = document.createElement('div');
+  container.classList.add('character-container');
 
   // キャラクターの絵文字表示
-  const emojiDiv = document.createElement("div");
-  emojiDiv.classList.add("character-emoji");
+  const emojiDiv = document.createElement('div');
+  emojiDiv.classList.add('character-emoji');
   emojiDiv.textContent = currentLevel.emoji;
   container.appendChild(emojiDiv);
 
   // レベル名表示
-  const nameDiv = document.createElement("div");
-  nameDiv.classList.add("character-name");
+  const nameDiv = document.createElement('div');
+  nameDiv.classList.add('character-name');
   nameDiv.textContent = currentLevel.name;
   container.appendChild(nameDiv);
 
   // ポイント表示
-  const xpDiv = document.createElement("div");
-  xpDiv.classList.add("character-xp");
+  const xpDiv = document.createElement('div');
+  xpDiv.classList.add('character-xp');
   xpDiv.textContent = `ポイント: ${xp}`;
   container.appendChild(xpDiv);
 
   // 進捗バー
   if (progress.nextLevel) {
-    const progressBar = document.createElement("div");
-    progressBar.classList.add("character-progress-bar");
+    const progressBar = document.createElement('div');
+    progressBar.classList.add('character-progress-bar');
 
-    const progressFill = document.createElement("div");
-    progressFill.classList.add("character-progress-fill");
+    const progressFill = document.createElement('div');
+    progressFill.classList.add('character-progress-fill');
     progressFill.style.width = `${progress.progress}%`;
     progressBar.appendChild(progressFill);
 
     container.appendChild(progressBar);
 
-    const progressText = document.createElement("div");
-    progressText.classList.add("character-progress-text");
+    const progressText = document.createElement('div');
+    progressText.classList.add('character-progress-text');
     progressText.textContent = `つぎまで: あと ${progress.remainingXP} ポイント`;
     container.appendChild(progressText);
   } else {
-    const maxLevelText = document.createElement("div");
-    maxLevelText.classList.add("character-max-level");
-    maxLevelText.textContent = "さいこう！";
+    const maxLevelText = document.createElement('div');
+    maxLevelText.classList.add('character-max-level');
+    maxLevelText.textContent = 'さいこう！';
     container.appendChild(maxLevelText);
   }
 
@@ -179,40 +182,40 @@ export function displayCharacter(xp) {
  */
 export function showLevelUpModal(newLevel) {
   // 既存のモーダルを削除
-  const existingModal = document.getElementById("levelup-modal");
+  const existingModal = document.getElementById('levelup-modal');
   if (existingModal) {
     existingModal.remove();
   }
 
-  const modal = document.createElement("div");
-  modal.id = "levelup-modal";
-  modal.classList.add("modal");
+  const modal = document.createElement('div');
+  modal.id = 'levelup-modal';
+  modal.classList.add('modal');
 
-  const modalContent = document.createElement("div");
-  modalContent.classList.add("modal-content", "levelup-content");
+  const modalContent = document.createElement('div');
+  modalContent.classList.add('modal-content', 'levelup-content');
 
-  const title = document.createElement("h2");
-  title.textContent = "🎉 レベルアップ！";
+  const title = document.createElement('h2');
+  title.textContent = '🎉 レベルアップ！';
   modalContent.appendChild(title);
 
-  const emoji = document.createElement("div");
-  emoji.classList.add("levelup-emoji");
+  const emoji = document.createElement('div');
+  emoji.classList.add('levelup-emoji');
   emoji.textContent = newLevel.emoji;
   modalContent.appendChild(emoji);
 
-  const levelName = document.createElement("div");
-  levelName.classList.add("levelup-name");
+  const levelName = document.createElement('div');
+  levelName.classList.add('levelup-name');
   levelName.textContent = newLevel.name;
   modalContent.appendChild(levelName);
 
-  const message = document.createElement("div");
-  message.classList.add("levelup-message");
+  const message = document.createElement('div');
+  message.classList.add('levelup-message');
   message.textContent = newLevel.message;
   modalContent.appendChild(message);
 
-  const closeButton = document.createElement("button");
-  closeButton.textContent = "やったね！";
-  closeButton.classList.add("modal-close-btn");
+  const closeButton = document.createElement('button');
+  closeButton.textContent = 'やったね！';
+  closeButton.classList.add('modal-close-btn');
   modalContent.appendChild(closeButton);
 
   modal.appendChild(modalContent);
@@ -237,103 +240,15 @@ export function showLevelUpModal(newLevel) {
  * ごほうびカレンダーを表示
  */
 export function displayRewardCalendar() {
-  const calendarDiv = document.getElementById("reward-calendar");
+  const calendarDiv = document.getElementById('reward-calendar');
   if (!calendarDiv) {
     return;
   }
 
-  calendarDiv.innerHTML = "";
-
-  // 連続学習日数を表示
-  const streak = getCurrentStreak();
-  const streakDiv = document.createElement("div");
-  streakDiv.classList.add("calendar-streak");
-  const emojiSpan = document.createElement("span");
-  emojiSpan.className = "streak-emoji";
-  emojiSpan.textContent = "🔥";
-  const numberSpan = document.createElement("span");
-  numberSpan.className = "streak-number";
-  numberSpan.textContent = streak;
-  streakDiv.append(emojiSpan, " ", numberSpan, " にちれんぞく！");
-  calendarDiv.appendChild(streakDiv);
-
-  // 今月のカレンダーを生成
   const today = new Date();
-  const year = today.getFullYear();
-  const month = today.getMonth();
+  const streak = getCurrentStreak();
+  const calendarData = loadCalendar();
 
-  // 月の最初の日と最後の日を取得
-  const firstDay = new Date(year, month, 1);
-  const lastDay = new Date(year, month + 1, 0);
-
-  // カレンダーヘッダー
-  const headerDiv = document.createElement("div");
-  headerDiv.classList.add("calendar-header");
-  headerDiv.textContent = `${year}ねん ${month + 1}がつ`;
-  calendarDiv.appendChild(headerDiv);
-
-  // 曜日ヘッダー
-  const weekdaysDiv = document.createElement("div");
-  weekdaysDiv.classList.add("calendar-weekdays");
-  const weekdays = ["にち", "げつ", "か", "すい", "もく", "きん", "ど"];
-  weekdays.forEach((day) => {
-    const dayDiv = document.createElement("div");
-    dayDiv.classList.add("calendar-weekday");
-    dayDiv.textContent = day;
-    weekdaysDiv.appendChild(dayDiv);
-  });
-  calendarDiv.appendChild(weekdaysDiv);
-
-  // カレンダーグリッド
-  const gridDiv = document.createElement("div");
-  gridDiv.classList.add("calendar-grid");
-
-  // 学習データを読み込み
-  const calendar = loadCalendar();
-
-  // 最初の日の曜日まで空セルを追加
-  const firstDayOfWeek = firstDay.getDay();
-  for (let i = 0; i < firstDayOfWeek; i++) {
-    const emptyCell = document.createElement("div");
-    emptyCell.classList.add("calendar-day", "calendar-day-empty");
-    gridDiv.appendChild(emptyCell);
-  }
-
-  // 各日付のセルを追加
-  for (let date = 1; date <= lastDay.getDate(); date++) {
-    const dayCell = document.createElement("div");
-    dayCell.classList.add("calendar-day");
-
-    const dateKey = `${year}-${String(month + 1).padStart(2, "0")}-${String(date).padStart(2, "0")}`;
-    const studyCount = calendar[dateKey] || 0;
-
-    // 日付番号
-    const dateNumber = document.createElement("div");
-    dateNumber.classList.add("calendar-day-number");
-    dateNumber.textContent = date;
-    dayCell.appendChild(dateNumber);
-
-    // スタンプ表示
-    if (studyCount > 0) {
-      const stamp = document.createElement("div");
-      stamp.classList.add("calendar-stamp");
-      stamp.textContent = "⭐";
-      dayCell.appendChild(stamp);
-
-      dayCell.classList.add("calendar-day-studied");
-    }
-
-    // 今日の日付をハイライト
-    if (
-      date === today.getDate() &&
-      month === today.getMonth() &&
-      year === today.getFullYear()
-    ) {
-      dayCell.classList.add("calendar-day-today");
-    }
-
-    gridDiv.appendChild(dayCell);
-  }
-
-  calendarDiv.appendChild(gridDiv);
+  calendarDiv.innerHTML = '';
+  calendarDiv.appendChild(renderCalendar(today, calendarData, streak, today));
 }


### PR DESCRIPTION
Closes #12

## Summary

100行ある `displayRewardCalendar` を **責務別の4ヘルパー + 統合関数** に分割し、`js/ui.js` から **新規 `js/calendar-renderer.js`** へ切り出しました。`displayRewardCalendar` 自体はオーケストレータとなり約80行短縮されています。

## 変更内容

### 新規: `js/calendar-renderer.js`
| 関数 | 責務 |
|---|---|
| `createStreakElement(streak)` | 🔥連続学習日数の `.calendar-streak` 要素を生成 |
| `createCalendarHeader(date)` | `2026ねん 5がつ` の年月ヘッダー生成 |
| `createWeekdaysElement()` | 曜日ヘッダー（にち・げつ・…・ど）生成 |
| `createCalendarGrid(date, calendarData, today?)` | 日付セル群生成（スタンプ・今日ハイライト含む） |
| `renderCalendar(date, calendarData, streak, today?)` | 上記4つを束ねた DocumentFragment を返す統合関数 |

ヘルパーは **DOM要素を生成して返すだけ** とし、コンテナへの `appendChild` は呼出し元の責務。`today` を引数注入できるためテスト時に固定可能。

### 変更: `js/ui.js`
- `renderCalendar` を import 追加
- `displayRewardCalendar` を以下まで簡素化（オーケストレータ化）

```javascript
export function displayRewardCalendar() {
  const calendarDiv = document.getElementById('reward-calendar');
  if (!calendarDiv) return;
  const today = new Date();
  const streak = getCurrentStreak();
  const calendarData = loadCalendar();
  calendarDiv.innerHTML = '';
  calendarDiv.appendChild(renderCalendar(today, calendarData, streak, today));
}
```

## 後方互換性

- `displayRewardCalendar` の関数名・シグネチャは不変（`js/main.js` の呼び出しに影響なし）
- 生成される DOM 構造（`.calendar-streak` / `.calendar-header` / `.calendar-weekdays` / `.calendar-grid` および各セル）は完全に維持

## 補足

- `npm run lint` 通過
- 既存プロジェクトの慣行（`badges.js` / `character.js` / `charts.js` / `audio.js` 等の機能単位分割）と整合する設計
- 視覚回帰テストフレームワーク未整備のため、デザイン差分は手動目視確認

## Test plan

- [ ] アプリ起動時、ごほうびカレンダーが従来通り表示される
- [ ] 連続学習日数（🔥XXにちれんぞく！）が正しく表示される
- [ ] 年月ヘッダーが今月を表す
- [ ] 曜日ヘッダー（にち・げつ・…）が表示される
- [ ] 学習済み日付に⭐スタンプと色付き背景が反映される
- [ ] 今日の日付がハイライト枠で表示される
- [ ] 月初の曜日まで空セルが正しく挿入される
- [ ] モバイル幅（768px/480px/420px）でも崩れない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * ごほうびカレンダーの描画を全面的に見直しました。学習スタンプ、連続学習日数表示、年月ヘッダー、曜日ラベル、日付グリッド、今日のハイライトがより安定・整然と表示されます。
  * 画面表示関連（履歴、進捗、キャラクター、モーダル等）の構成を整理し、表示の安定性と保守性を向上しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/kakezan-manabo/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->