### PR TITLE
ci: 🔒 complexity-check.yml に permissions: contents: read を明示

### DIFF
--- a/.github/workflows/complexity-check.yml
+++ b/.github/workflows/complexity-check.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, master]
 
+permissions:
+  contents: read
+
 jobs:
   complexity:
     name: Check Cyclomatic Complexity


### PR DESCRIPTION
## Summary

- `complexity-check.yml` だけ `permissions:` ブロック未指定だったため明示宣言
- 他のワークフロー (`actionlint`, `codeql`, `gitleaks`, `markdownlint`) と表記を揃える
- リポジトリの default_workflow_permissions が将来変更されてもこのワークフローは read 権限のみで動作

## 背景

公開リポジトリのセキュリティリスク棚卸しの 1 項目。`GITHUB_TOKEN` の最小権限を
ワークフロー側でも明示することで、リポジトリ設定変更時の事故を防ぐ。

## Test plan

- [ ] CI が通る (Check Cyclomatic Complexity)
- [ ] actionlint が通る

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ワークフロー権限設定を強化し、セキュリティをさらに向上させました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/kakezan-manabo/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->