### PR TITLE
ci: 🔒 complexity-check で npm ci に --ignore-scripts を付与

### DIFF
--- a/.github/workflows/complexity-check.yml
+++ b/.github/workflows/complexity-check.yml
@@ -27,7 +27,9 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm ci
+        # lint 専用のため install スクリプトは不要。
+        # 悪意ある依存パッケージの post-install による任意コード実行を防ぐ。
+        run: npm ci --ignore-scripts
 
       - name: Run ESLint complexity check
         run: npm run lint


### PR DESCRIPTION
## Summary

- `complexity-check.yml` の `npm ci` に `--ignore-scripts` を追加
- 悪意ある依存パッケージの postinstall による任意コード実行リスクを排除

## 背景

公開リポジトリのセキュリティリスク棚卸しの 1 項目。本リポジトリの依存は
`eslint`, `globals`, `http-server` のみで、いずれも postinstall を必要としない。
Dependabot 経由で悪意あるパッケージ更新がマージされた場合の防御層として
`--ignore-scripts` を有効化する。

## Test plan

- [ ] CI が通る (Check Cyclomatic Complexity)
- [ ] `npm ci --ignore-scripts` で eslint が問題なく動くことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 開発ワークフローのセキュリティを強化しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/kakezan-manabo/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->