### PR TITLE
fix(ci): 🔒 aws-actions/configure-aws-credentials を SHA pin に修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}


### PR DESCRIPTION
## Summary

- `aws-actions/configure-aws-credentials@v6` を v6.1.1 の commit SHA に固定
- `sha_pinning_required: true` 設定下で startup_failure になる問題を修正

## 経緯

PR #39 マージ後の deploy 実行が startup_failure で失敗。
原因はリポジトリ設定 \`Actions: sha_pinning_required\` 有効化により、
タグ参照のままだった本 action が起動拒否されたため。

- 失敗 Run: https://github.com/genzouw/kakezan-manabo/actions/runs/26190778471
- 修正対象タグ: v6.1.1 (2026-05-05 リリース)
- SHA: \`d979d5b3a71173a29b74b5b88418bfda9437d885\`

## Test plan

- [ ] actionlint が通る
- [ ] マージ後 main への push で deploy が成功
- [ ] S3 + CloudFront 反映を確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * AWS認証アクションの依存関係を更新し、より安定したバージョンに固定しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/kakezan-manabo/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->