### PR TITLE
ci: 🔧 actions/checkout のバージョンを v6.0.0 に揃える

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -24,7 +24,7 @@ jobs:
     name: actionlint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
   schedule:
     # 毎週月曜 03:00 JST (= 日曜 18:00 UTC) に main を再スキャン
-    - cron: '0 18 * * 0'
+    - cron: "0 18 * * 0"
 
 concurrency:
   group: codeql-${{ github.ref }}
@@ -26,10 +26,10 @@ jobs:
       fail-fast: false
       matrix:
         # frontend は tsx、backend は ts。両方とも 'javascript-typescript' でまとめてスキャン。
-        language: ['javascript-typescript']
+        language: ["javascript-typescript"]
     steps:
       - name: Checkout
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
         with:
           persist-credentials: false
 
@@ -44,4 +44,4 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@78ed0c7291d93e40c51b085850dc669a4c3ab73b # v3
         with:
-          category: '/language:${{ matrix.language }}'
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -23,7 +23,7 @@ jobs:
     name: Scan for leaked secrets
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
         with:
           # 履歴全体をスキャンするためフルクローン
           fetch-depth: 0

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -4,15 +4,15 @@ on:
   push:
     branches: [main]
     paths:
-      - '**/*.md'
-      - '.markdownlint-cli2.jsonc'
-      - '.github/workflows/markdownlint.yml'
+      - "**/*.md"
+      - ".markdownlint-cli2.jsonc"
+      - ".github/workflows/markdownlint.yml"
   pull_request:
     branches: [main]
     paths:
-      - '**/*.md'
-      - '.markdownlint-cli2.jsonc'
-      - '.github/workflows/markdownlint.yml'
+      - "**/*.md"
+      - ".markdownlint-cli2.jsonc"
+      - ".github/workflows/markdownlint.yml"
 
 concurrency:
   group: markdownlint-${{ github.ref }}
@@ -29,12 +29,12 @@ jobs:
     # 整備完了後に continue-on-error を外して赤検知に切り替える。
     continue-on-error: true
     steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
         with:
           persist-credentials: false
 
       - name: Run markdownlint-cli2
         uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e # v20
         with:
-          config: '.markdownlint-cli2.jsonc'
-          globs: '**/*.md'
+          config: ".markdownlint-cli2.jsonc"
+          globs: "**/*.md"


### PR DESCRIPTION
## Summary

- `actions/checkout` のバージョン混在 (v4.1.6 / v6.0.0) を v6.0.0 に統一
- 対象: \`actionlint.yml\`, \`codeql.yml\`, \`gitleaks.yml\`, \`markdownlint.yml\`
- 据え置き: \`complexity-check.yml\`, \`deploy.yml\` (すでに v6.0.0)

## 背景

公開リポジトリのセキュリティリスク棚卸しの 1 項目。過去の Dependabot bump
(cc9f9b9) が部分マージで止まっており、v4 と v6 が混在していた。
揃えることで Dependabot の追従が 1 PR にまとまり、レビュー負荷が下がる。

## 副次変更

Prettier の整形が codeql.yml と markdownlint.yml の引用符 (single → double) に
入ったが、プロジェクトの既定スタイルに合わせて受け入れる。

## Test plan

- [ ] CI が通る (actionlint, codeql, gitleaks, markdownlint, complexity, deploy)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CDワークフロー内の依存アクションを更新しました。コード品質チェックおよびセキュリティスキャンプロセスの信頼性向上により、より堅牢なビルドパイプラインを実現します。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/kakezan-manabo/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->