### PR TITLE
refactor(lint): 💡 ESLint recommended ルールセットを追加 (closes #19)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,23 +1,27 @@
-import globals from "globals";
+import globals from 'globals';
+import js from '@eslint/js';
 
 /** @type {import("eslint").Linter.Config[]} */
 export default [
+  js.configs.recommended,
   {
     languageOptions: {
       ecmaVersion: 2022,
-      sourceType: "module",
+      sourceType: 'module',
       globals: {
         ...globals.browser,
+        // chart.js は CDN 経由でグローバル変数 Chart として読み込まれる
+        Chart: 'readonly',
       },
     },
     rules: {
       // 循環的複雑度（サイクロマティックコンプレクシティ）のチェック
       // 10以下を推奨（バグ混入率25%以下）
       // 参考: https://tbpgr.hatenablog.com/entry/2015/05/15/231825
-      complexity: ["error", { max: 10 }],
+      complexity: ['error', { max: 10 }],
     },
   },
   {
-    ignores: ["node_modules/**"],
+    ignores: ['node_modules/**'],
   },
 ];

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -6,11 +6,11 @@
  * 問題ごとの統計情報を取得
  */
 export function getQuestionStats() {
-  const stats = localStorage.getItem("questionStats");
+  const stats = localStorage.getItem('questionStats');
   if (stats) {
     try {
       return JSON.parse(stats);
-    } catch (e) {
+    } catch {
       return {};
     }
   }
@@ -42,7 +42,7 @@ export function updateQuestionStats(questionKey, isCorrect) {
   }
   stats[questionKey].lastAttempt = new Date().toISOString();
 
-  localStorage.setItem("questionStats", JSON.stringify(stats));
+  localStorage.setItem('questionStats', JSON.stringify(stats));
 }
 
 /**
@@ -69,7 +69,7 @@ export function getQuestionAccuracy(questionKey) {
  */
 export function getWeakQuestions(availableQuestions, limit = 10) {
   return availableQuestions
-    .map(key => ({
+    .map((key) => ({
       key,
       accuracy: getQuestionAccuracy(key),
       attempts: (getQuestionStats()[key] || {}).attempts || 0,
@@ -82,7 +82,7 @@ export function getWeakQuestions(availableQuestions, limit = 10) {
       return a.accuracy - b.accuracy;
     })
     .slice(0, limit)
-    .map(item => item.key);
+    .map((item) => item.key);
 }
 
 /**
@@ -92,7 +92,7 @@ export function getWeakQuestions(availableQuestions, limit = 10) {
  * @returns {string} 選択された問題のキー
  */
 export function getAdaptiveQuestion(availableQuestions, targetAccuracy = 0.7) {
-  const questionsWithStats = availableQuestions.map(key => ({
+  const questionsWithStats = availableQuestions.map((key) => ({
     key,
     accuracy: getQuestionAccuracy(key),
     attempts: (getQuestionStats()[key] || {}).attempts || 0,
@@ -113,7 +113,7 @@ export function getAdaptiveQuestion(availableQuestions, targetAccuracy = 0.7) {
   // 上位30%からランダムに選択（完全に固定化しないため）
   const topCandidates = questionsWithStats.slice(
     0,
-    Math.max(1, Math.floor(questionsWithStats.length * 0.3))
+    Math.max(1, Math.floor(questionsWithStats.length * 0.3)),
   );
 
   return topCandidates[Math.floor(Math.random() * topCandidates.length)].key;
@@ -127,6 +127,6 @@ export function getAdaptiveQuestion(availableQuestions, targetAccuracy = 0.7) {
 export function getAverageAccuracy(questionKeys) {
   if (questionKeys.length === 0) return 0.5;
 
-  const accuracies = questionKeys.map(key => getQuestionAccuracy(key));
+  const accuracies = questionKeys.map((key) => getQuestionAccuracy(key));
   return accuracies.reduce((sum, acc) => sum + acc, 0) / accuracies.length;
 }

--- a/js/badges.js
+++ b/js/badges.js
@@ -5,59 +5,59 @@
 // バッジの定義
 export const BADGES = {
   firstWin: {
-    id: "firstWin",
-    name: "はじめの一歩",
-    description: "初めてのゲームをクリア",
-    emoji: "🎯",
+    id: 'firstWin',
+    name: 'はじめの一歩',
+    description: '初めてのゲームをクリア',
+    emoji: '🎯',
     condition: (stats) => stats.gamesPlayed >= 1,
   },
   perfectGame: {
-    id: "perfectGame",
-    name: "パーフェクト",
-    description: "全問正解を達成",
-    emoji: "🏆",
+    id: 'perfectGame',
+    name: 'パーフェクト',
+    description: '全問正解を達成',
+    emoji: '🏆',
     condition: (stats) => stats.perfectGames >= 1,
   },
   streakMaster: {
-    id: "streakMaster",
-    name: "連続正解マスター",
-    description: "10問連続で正解",
-    emoji: "🔥",
+    id: 'streakMaster',
+    name: '連続正解マスター',
+    description: '10問連続で正解',
+    emoji: '🔥',
     condition: (stats) => stats.maxStreak >= 10,
   },
   dedicated: {
-    id: "dedicated",
-    name: "継続は力なり",
-    description: "3日連続で学習",
-    emoji: "📅",
+    id: 'dedicated',
+    name: '継続は力なり',
+    description: '3日連続で学習',
+    emoji: '📅',
     condition: (stats) => stats.consecutiveDays >= 3,
   },
   weekWarrior: {
-    id: "weekWarrior",
-    name: "1週間の戦士",
-    description: "7日連続で学習",
-    emoji: "⭐",
+    id: 'weekWarrior',
+    name: '1週間の戦士',
+    description: '7日連続で学習',
+    emoji: '⭐',
     condition: (stats) => stats.consecutiveDays >= 7,
   },
   hundredQuestions: {
-    id: "hundredQuestions",
-    name: "百問突破",
-    description: "累計100問に挑戦",
-    emoji: "💯",
+    id: 'hundredQuestions',
+    name: '百問突破',
+    description: '累計100問に挑戦',
+    emoji: '💯',
     condition: (stats) => stats.totalQuestions >= 100,
   },
   speedster: {
-    id: "speedster",
-    name: "スピードマスター",
-    description: "10問を2分以内でクリア",
-    emoji: "⚡",
+    id: 'speedster',
+    name: 'スピードマスター',
+    description: '10問を2分以内でクリア',
+    emoji: '⚡',
     condition: (stats) => stats.hasSpeedRecord,
   },
   allRounder: {
-    id: "allRounder",
-    name: "オールラウンダー",
-    description: "全ての段を練習",
-    emoji: "🌟",
+    id: 'allRounder',
+    name: 'オールラウンダー',
+    description: '全ての段を練習',
+    emoji: '🌟',
     condition: (stats) => stats.practiceAllLevels,
   },
 };
@@ -66,11 +66,11 @@ export const BADGES = {
  * 統計情報を取得
  */
 export function getAchievementStats() {
-  const stats = localStorage.getItem("achievementStats");
+  const stats = localStorage.getItem('achievementStats');
   if (stats) {
     try {
       return JSON.parse(stats);
-    } catch (e) {
+    } catch {
       return createDefaultStats();
     }
   }
@@ -104,7 +104,7 @@ function saveAchievementStats(stats) {
     ...stats,
     practicesLevels: Array.from(stats.practicesLevels),
   };
-  localStorage.setItem("achievementStats", JSON.stringify(statsToSave));
+  localStorage.setItem('achievementStats', JSON.stringify(statsToSave));
 }
 
 /**
@@ -156,7 +156,7 @@ function recordPracticedLevels(practicesLevels, questions) {
     return;
   }
   questions.forEach((questionKey) => {
-    const level = parseInt(questionKey.split("x")[0]);
+    const level = parseInt(questionKey.split('x')[0]);
     practicesLevels.add(level);
   });
 }
@@ -193,7 +193,7 @@ export function updateAchievementStats(gameResult) {
 
   stats.consecutiveDays = calculateConsecutiveDays(
     stats.lastPlayDate,
-    stats.consecutiveDays
+    stats.consecutiveDays,
   );
   stats.lastPlayDate = new Date().toDateString();
 
@@ -236,11 +236,11 @@ export function updateStreak(isCorrect) {
  * 獲得済みバッジを取得
  */
 export function getEarnedBadges() {
-  const earned = localStorage.getItem("earnedBadges");
+  const earned = localStorage.getItem('earnedBadges');
   if (earned) {
     try {
       return JSON.parse(earned);
-    } catch (e) {
+    } catch {
       return [];
     }
   }
@@ -255,7 +255,7 @@ function earnBadge(badgeId) {
   const earnedBadges = getEarnedBadges();
   if (!earnedBadges.includes(badgeId)) {
     earnedBadges.push(badgeId);
-    localStorage.setItem("earnedBadges", JSON.stringify(earnedBadges));
+    localStorage.setItem('earnedBadges', JSON.stringify(earnedBadges));
     return true;
   }
   return false;
@@ -288,8 +288,8 @@ export function checkNewBadges() {
 export function showBadgeModal(badges) {
   if (badges.length === 0) return;
 
-  const modal = document.createElement("div");
-  modal.className = "badge-modal";
+  const modal = document.createElement('div');
+  modal.className = 'badge-modal';
   modal.innerHTML = `
     <div class="badge-modal-content">
       <h2>🎉 バッジをゲットしたよ！</h2>
@@ -302,9 +302,9 @@ export function showBadgeModal(badges) {
             <div class="badge-name">${badge.name}</div>
             <div class="badge-description">${badge.description}</div>
           </div>
-        `
+        `,
           )
-          .join("")}
+          .join('')}
       </div>
       <button class="badge-close-btn">とじる</button>
     </div>
@@ -312,8 +312,8 @@ export function showBadgeModal(badges) {
 
   document.body.appendChild(modal);
 
-  const closeBtn = modal.querySelector(".badge-close-btn");
-  closeBtn.addEventListener("click", () => {
+  const closeBtn = modal.querySelector('.badge-close-btn');
+  closeBtn.addEventListener('click', () => {
     modal.remove();
   });
 

--- a/js/badges.js
+++ b/js/badges.js
@@ -5,59 +5,59 @@
 // バッジの定義
 export const BADGES = {
   firstWin: {
-    id: 'firstWin',
-    name: 'はじめの一歩',
-    description: '初めてのゲームをクリア',
-    emoji: '🎯',
+    id: "firstWin",
+    name: "はじめの一歩",
+    description: "初めてのゲームをクリア",
+    emoji: "🎯",
     condition: (stats) => stats.gamesPlayed >= 1,
   },
   perfectGame: {
-    id: 'perfectGame',
-    name: 'パーフェクト',
-    description: '全問正解を達成',
-    emoji: '🏆',
+    id: "perfectGame",
+    name: "パーフェクト",
+    description: "全問正解を達成",
+    emoji: "🏆",
     condition: (stats) => stats.perfectGames >= 1,
   },
   streakMaster: {
-    id: 'streakMaster',
-    name: '連続正解マスター',
-    description: '10問連続で正解',
-    emoji: '🔥',
+    id: "streakMaster",
+    name: "連続正解マスター",
+    description: "10問連続で正解",
+    emoji: "🔥",
     condition: (stats) => stats.maxStreak >= 10,
   },
   dedicated: {
-    id: 'dedicated',
-    name: '継続は力なり',
-    description: '3日連続で学習',
-    emoji: '📅',
+    id: "dedicated",
+    name: "継続は力なり",
+    description: "3日連続で学習",
+    emoji: "📅",
     condition: (stats) => stats.consecutiveDays >= 3,
   },
   weekWarrior: {
-    id: 'weekWarrior',
-    name: '1週間の戦士',
-    description: '7日連続で学習',
-    emoji: '⭐',
+    id: "weekWarrior",
+    name: "1週間の戦士",
+    description: "7日連続で学習",
+    emoji: "⭐",
     condition: (stats) => stats.consecutiveDays >= 7,
   },
   hundredQuestions: {
-    id: 'hundredQuestions',
-    name: '百問突破',
-    description: '累計100問に挑戦',
-    emoji: '💯',
+    id: "hundredQuestions",
+    name: "百問突破",
+    description: "累計100問に挑戦",
+    emoji: "💯",
     condition: (stats) => stats.totalQuestions >= 100,
   },
   speedster: {
-    id: 'speedster',
-    name: 'スピードマスター',
-    description: '10問を2分以内でクリア',
-    emoji: '⚡',
+    id: "speedster",
+    name: "スピードマスター",
+    description: "10問を2分以内でクリア",
+    emoji: "⚡",
     condition: (stats) => stats.hasSpeedRecord,
   },
   allRounder: {
-    id: 'allRounder',
-    name: 'オールラウンダー',
-    description: '全ての段を練習',
-    emoji: '🌟',
+    id: "allRounder",
+    name: "オールラウンダー",
+    description: "全ての段を練習",
+    emoji: "🌟",
     condition: (stats) => stats.practiceAllLevels,
   },
 };
@@ -66,7 +66,7 @@ export const BADGES = {
  * 統計情報を取得
  */
 export function getAchievementStats() {
-  const stats = localStorage.getItem('achievementStats');
+  const stats = localStorage.getItem("achievementStats");
   if (stats) {
     try {
       return JSON.parse(stats);
@@ -104,7 +104,7 @@ function saveAchievementStats(stats) {
     ...stats,
     practicesLevels: Array.from(stats.practicesLevels),
   };
-  localStorage.setItem('achievementStats', JSON.stringify(statsToSave));
+  localStorage.setItem("achievementStats", JSON.stringify(statsToSave));
 }
 
 /**
@@ -156,7 +156,7 @@ function recordPracticedLevels(practicesLevels, questions) {
     return;
   }
   questions.forEach((questionKey) => {
-    const level = parseInt(questionKey.split('x')[0]);
+    const level = Number.parseInt(questionKey.split("x")[0], 10);
     practicesLevels.add(level);
   });
 }
@@ -236,7 +236,7 @@ export function updateStreak(isCorrect) {
  * 獲得済みバッジを取得
  */
 export function getEarnedBadges() {
-  const earned = localStorage.getItem('earnedBadges');
+  const earned = localStorage.getItem("earnedBadges");
   if (earned) {
     try {
       return JSON.parse(earned);
@@ -255,7 +255,7 @@ function earnBadge(badgeId) {
   const earnedBadges = getEarnedBadges();
   if (!earnedBadges.includes(badgeId)) {
     earnedBadges.push(badgeId);
-    localStorage.setItem('earnedBadges', JSON.stringify(earnedBadges));
+    localStorage.setItem("earnedBadges", JSON.stringify(earnedBadges));
     return true;
   }
   return false;
@@ -288,8 +288,8 @@ export function checkNewBadges() {
 export function showBadgeModal(badges) {
   if (badges.length === 0) return;
 
-  const modal = document.createElement('div');
-  modal.className = 'badge-modal';
+  const modal = document.createElement("div");
+  modal.className = "badge-modal";
   modal.innerHTML = `
     <div class="badge-modal-content">
       <h2>🎉 バッジをゲットしたよ！</h2>
@@ -304,7 +304,7 @@ export function showBadgeModal(badges) {
           </div>
         `,
           )
-          .join('')}
+          .join("")}
       </div>
       <button class="badge-close-btn">とじる</button>
     </div>
@@ -312,8 +312,8 @@ export function showBadgeModal(badges) {
 
   document.body.appendChild(modal);
 
-  const closeBtn = modal.querySelector('.badge-close-btn');
-  closeBtn.addEventListener('click', () => {
+  const closeBtn = modal.querySelector(".badge-close-btn");
+  closeBtn.addEventListener("click", () => {
     modal.remove();
   });
 

--- a/js/charts.js
+++ b/js/charts.js
@@ -8,13 +8,13 @@ import {
   getWeakestQuestions,
   getDailyHistory,
   getAccuracyByTimeOfDay,
-} from "./statistics.js";
+} from './statistics.js';
 
 /**
  * 段ごとの正解率を棒グラフで表示
  */
 export function renderLevelAccuracyChart() {
-  const canvas = document.getElementById("levelAccuracyChart");
+  const canvas = document.getElementById('levelAccuracyChart');
   if (!canvas) return;
 
   const levelStats = calculateAccuracyByLevel();
@@ -31,17 +31,17 @@ export function renderLevelAccuracyChart() {
     window.levelAccuracyChartInstance.destroy();
   }
 
-  const ctx = canvas.getContext("2d");
+  const ctx = canvas.getContext('2d');
   window.levelAccuracyChartInstance = new Chart(ctx, {
-    type: "bar",
+    type: 'bar',
     data: {
       labels: labels,
       datasets: [
         {
-          label: "正解率 (%)",
+          label: '正解率 (%)',
           data: data,
-          backgroundColor: "rgba(76, 175, 80, 0.6)",
-          borderColor: "rgba(76, 175, 80, 1)",
+          backgroundColor: 'rgba(76, 175, 80, 0.6)',
+          borderColor: 'rgba(76, 175, 80, 1)',
           borderWidth: 1,
         },
       ],
@@ -55,7 +55,7 @@ export function renderLevelAccuracyChart() {
           max: 100,
           title: {
             display: true,
-            text: "正解率 (%)",
+            text: '正解率 (%)',
           },
         },
       },
@@ -65,7 +65,7 @@ export function renderLevelAccuracyChart() {
         },
         title: {
           display: true,
-          text: "段ごとの正解率",
+          text: '段ごとの正解率',
         },
       },
     },
@@ -76,7 +76,7 @@ export function renderLevelAccuracyChart() {
  * 日別の学習履歴を折れ線グラフで表示
  */
 export function renderDailyHistoryChart() {
-  const canvas = document.getElementById("dailyHistoryChart");
+  const canvas = document.getElementById('dailyHistoryChart');
   if (!canvas) return;
 
   const dailyData = getDailyHistory(7);
@@ -89,25 +89,25 @@ export function renderDailyHistoryChart() {
     window.dailyHistoryChartInstance.destroy();
   }
 
-  const ctx = canvas.getContext("2d");
+  const ctx = canvas.getContext('2d');
   window.dailyHistoryChartInstance = new Chart(ctx, {
-    type: "line",
+    type: 'line',
     data: {
       labels: labels,
       datasets: [
         {
-          label: "正解率 (%)",
+          label: '正解率 (%)',
           data: accuracyData,
-          borderColor: "rgba(76, 175, 80, 1)",
-          backgroundColor: "rgba(76, 175, 80, 0.1)",
-          yAxisID: "y",
+          borderColor: 'rgba(76, 175, 80, 1)',
+          backgroundColor: 'rgba(76, 175, 80, 0.1)',
+          yAxisID: 'y',
         },
         {
-          label: "プレイ回数",
+          label: 'プレイ回数',
           data: gamesData,
-          borderColor: "rgba(33, 150, 243, 1)",
-          backgroundColor: "rgba(33, 150, 243, 0.1)",
-          yAxisID: "y1",
+          borderColor: 'rgba(33, 150, 243, 1)',
+          backgroundColor: 'rgba(33, 150, 243, 0.1)',
+          yAxisID: 'y1',
         },
       ],
     },
@@ -115,39 +115,39 @@ export function renderDailyHistoryChart() {
       responsive: true,
       maintainAspectRatio: false,
       interaction: {
-        mode: "index",
+        mode: 'index',
         intersect: false,
       },
       scales: {
         y: {
-          type: "linear",
+          type: 'linear',
           display: true,
-          position: "left",
+          position: 'left',
           beginAtZero: true,
           max: 100,
           title: {
             display: true,
-            text: "正解率 (%)",
+            text: '正解率 (%)',
           },
         },
         y1: {
-          type: "linear",
+          type: 'linear',
           display: true,
-          position: "right",
+          position: 'right',
           beginAtZero: true,
           grid: {
             drawOnChartArea: false,
           },
           title: {
             display: true,
-            text: "プレイ回数",
+            text: 'プレイ回数',
           },
         },
       },
       plugins: {
         title: {
           display: true,
-          text: "過去7日間の学習履歴",
+          text: '過去7日間の学習履歴',
         },
       },
     },
@@ -158,17 +158,17 @@ export function renderDailyHistoryChart() {
  * 時間帯別の正解率を円グラフで表示
  */
 export function renderTimeOfDayChart() {
-  const canvas = document.getElementById("timeOfDayChart");
+  const canvas = document.getElementById('timeOfDayChart');
   if (!canvas) return;
 
   const timeData = getAccuracyByTimeOfDay();
   const labels = [];
   const data = [];
   const backgroundColors = [
-    "rgba(255, 206, 86, 0.6)",
-    "rgba(75, 192, 192, 0.6)",
-    "rgba(153, 102, 255, 0.6)",
-    "rgba(54, 162, 235, 0.6)",
+    'rgba(255, 206, 86, 0.6)',
+    'rgba(75, 192, 192, 0.6)',
+    'rgba(153, 102, 255, 0.6)',
+    'rgba(54, 162, 235, 0.6)',
   ];
 
   Object.keys(timeData).forEach((key) => {
@@ -182,25 +182,25 @@ export function renderTimeOfDayChart() {
 
   // データがない場合は表示しない
   if (data.length === 0) {
-    canvas.style.display = "none";
+    canvas.style.display = 'none';
     return;
   }
 
-  canvas.style.display = "block";
+  canvas.style.display = 'block';
 
   // 既存のチャートがあれば破棄
   if (window.timeOfDayChartInstance) {
     window.timeOfDayChartInstance.destroy();
   }
 
-  const ctx = canvas.getContext("2d");
+  const ctx = canvas.getContext('2d');
   window.timeOfDayChartInstance = new Chart(ctx, {
-    type: "doughnut",
+    type: 'doughnut',
     data: {
       labels: labels,
       datasets: [
         {
-          label: "正解率 (%)",
+          label: '正解率 (%)',
           data: data,
           backgroundColor: backgroundColors.slice(0, data.length),
           borderWidth: 1,
@@ -213,10 +213,10 @@ export function renderTimeOfDayChart() {
       plugins: {
         title: {
           display: true,
-          text: "時間帯別正解率",
+          text: '時間帯別正解率',
         },
         legend: {
-          position: "bottom",
+          position: 'bottom',
         },
       },
     },
@@ -227,13 +227,13 @@ export function renderTimeOfDayChart() {
  * 学習統計サマリーを表示
  */
 export function renderStatisticsSummary() {
-  const summaryDiv = document.getElementById("statisticsSummary");
+  const summaryDiv = document.getElementById('statisticsSummary');
   if (!summaryDiv) return;
 
   const studyTime = calculateStudyTime();
   const weakQuestions = getWeakestQuestions();
 
-  let weakQuestionsHTML = "";
+  let weakQuestionsHTML;
   if (weakQuestions.length > 0) {
     weakQuestionsHTML = `
       <div class="weak-questions">
@@ -242,9 +242,9 @@ export function renderStatisticsSummary() {
           ${weakQuestions
             .map(
               (q) =>
-                `<li>${q.question}: ${q.accuracy.toFixed(1)}% (${q.attempts}かい)`
+                `<li>${q.question}: ${q.accuracy.toFixed(1)}% (${q.attempts}かい)`,
             )
-            .join("")}
+            .join('')}
         </ul>
       </div>
     `;

--- a/js/logic.js
+++ b/js/logic.js
@@ -1,9 +1,9 @@
-import { multiplicationData } from './data.js';
+import { multiplicationData } from "./data.js";
 import {
   getWeakQuestions,
   getAdaptiveQuestion,
   getAverageAccuracy,
-} from './analytics.js';
+} from "./analytics.js";
 
 // モジュール初期化時に全答えのユニークなリストを作成
 const allAnswers = [
@@ -30,20 +30,17 @@ function shuffleArray(array) {
 export function generateMultiplicationQuestion(
   completedQuestions,
   selectedLevels,
-  mode = 'normal',
+  mode = "normal",
 ) {
   if (selectedLevels.length === 0) {
-    alert('少なくとも一つの段を選択してください。');
+    alert("少なくとも一つの段を選択してください。");
     return null;
   }
 
-  let availableQuestions = [];
-  for (const key of Object.keys(multiplicationData)) {
-    const num1 = parseInt(key.split('x')[0]);
-    if (selectedLevels.includes(num1)) {
-      availableQuestions.push(key);
-    }
-  }
+  let availableQuestions = Object.keys(multiplicationData).filter((key) => {
+    const num1 = Number.parseInt(key.split("x")[0], 10);
+    return selectedLevels.includes(num1);
+  });
 
   if (availableQuestions.length <= completedQuestions.length) {
     completedQuestions.length = 0;
@@ -57,7 +54,7 @@ export function generateMultiplicationQuestion(
 
   // 学習モードに応じて問題を選択
   switch (mode) {
-    case 'weak': {
+    case "weak": {
       // 苦手克服モード: 正解率が低い問題を優先
       const weakQuestions = getWeakQuestions(availableQuestions, 5);
       if (weakQuestions.length > 0) {
@@ -73,7 +70,7 @@ export function generateMultiplicationQuestion(
       break;
     }
 
-    case 'adaptive': {
+    case "adaptive": {
       // アダプティブラーニング: 現在の正解率に応じて難易度を調整
       const currentAccuracy = getAverageAccuracy(
         completedQuestions.slice(-10), // 直近10問の正解率を参照
@@ -96,7 +93,7 @@ export function generateMultiplicationQuestion(
   completedQuestions.push(questionKey);
 
   return {
-    question: questionKey.replace('x', ' × ') + ' = ',
+    question: questionKey.replace("x", " × ") + " = ",
     answer: multiplicationData[questionKey].answer,
     reading: multiplicationData[questionKey].reading,
     answerReading: multiplicationData[questionKey].answerReading,

--- a/js/logic.js
+++ b/js/logic.js
@@ -1,14 +1,14 @@
-import { multiplicationData } from "./data.js";
+import { multiplicationData } from './data.js';
 import {
   getWeakQuestions,
   getAdaptiveQuestion,
   getAverageAccuracy,
-} from "./analytics.js";
+} from './analytics.js';
 
 // モジュール初期化時に全答えのユニークなリストを作成
-const allAnswers = [...new Set(
-  Object.values(multiplicationData).map(data => data.answer)
-)];
+const allAnswers = [
+  ...new Set(Object.values(multiplicationData).map((data) => data.answer)),
+];
 
 // Fisher-Yatesシャッフルアルゴリズム
 function shuffleArray(array) {
@@ -30,20 +30,18 @@ function shuffleArray(array) {
 export function generateMultiplicationQuestion(
   completedQuestions,
   selectedLevels,
-  mode = "normal"
+  mode = 'normal',
 ) {
   if (selectedLevels.length === 0) {
-    alert("少なくとも一つの段を選択してください。");
+    alert('少なくとも一つの段を選択してください。');
     return null;
   }
 
   let availableQuestions = [];
-  for (const key in multiplicationData) {
-    if (multiplicationData.hasOwnProperty(key)) {
-      const num1 = parseInt(key.split("x")[0]);
-      if (selectedLevels.includes(num1)) {
-        availableQuestions.push(key);
-      }
+  for (const key of Object.keys(multiplicationData)) {
+    const num1 = parseInt(key.split('x')[0]);
+    if (selectedLevels.includes(num1)) {
+      availableQuestions.push(key);
     }
   }
 
@@ -59,39 +57,46 @@ export function generateMultiplicationQuestion(
 
   // 学習モードに応じて問題を選択
   switch (mode) {
-    case "weak":
+    case 'weak': {
       // 苦手克服モード: 正解率が低い問題を優先
       const weakQuestions = getWeakQuestions(availableQuestions, 5);
       if (weakQuestions.length > 0) {
-        questionKey = weakQuestions[Math.floor(Math.random() * weakQuestions.length)];
+        questionKey =
+          weakQuestions[Math.floor(Math.random() * weakQuestions.length)];
       } else {
         // 苦手な問題がない場合はランダム
         questionKey =
-          availableQuestions[Math.floor(Math.random() * availableQuestions.length)];
+          availableQuestions[
+            Math.floor(Math.random() * availableQuestions.length)
+          ];
       }
       break;
+    }
 
-    case "adaptive":
+    case 'adaptive': {
       // アダプティブラーニング: 現在の正解率に応じて難易度を調整
       const currentAccuracy = getAverageAccuracy(
-        completedQuestions.slice(-10) // 直近10問の正解率を参照
+        completedQuestions.slice(-10), // 直近10問の正解率を参照
       );
       // 正解率が高い場合は難しい問題、低い場合は簡単な問題を出題
       const targetAccuracy = Math.max(0.3, Math.min(0.8, currentAccuracy));
       questionKey = getAdaptiveQuestion(availableQuestions, targetAccuracy);
       break;
+    }
 
     default:
       // 通常モード: ランダム
       questionKey =
-        availableQuestions[Math.floor(Math.random() * availableQuestions.length)];
+        availableQuestions[
+          Math.floor(Math.random() * availableQuestions.length)
+        ];
       break;
   }
 
   completedQuestions.push(questionKey);
 
   return {
-    question: questionKey.replace("x", " × ") + " = ",
+    question: questionKey.replace('x', ' × ') + ' = ',
     answer: multiplicationData[questionKey].answer,
     reading: multiplicationData[questionKey].reading,
     answerReading: multiplicationData[questionKey].answerReading,
@@ -101,7 +106,9 @@ export function generateMultiplicationQuestion(
 
 export function generateChoices(correctAnswer) {
   const choices = [correctAnswer];
-  const availableAnswers = allAnswers.filter(answer => answer !== correctAnswer);
+  const availableAnswers = allAnswers.filter(
+    (answer) => answer !== correctAnswer,
+  );
 
   // ランダムに3つの不正解を選択
   const shuffledAnswers = shuffleArray(availableAnswers);

--- a/js/main.js
+++ b/js/main.js
@@ -1,7 +1,6 @@
 import { generateMultiplicationQuestion, generateChoices } from './logic.js';
 import {
   speakQuestion,
-  speakAnswer,
   speakQuestionAndAnswer,
   playCorrectSound,
   playIncorrectSound,
@@ -56,8 +55,8 @@ document.addEventListener('DOMContentLoaded', function () {
   // （後段の loadSettings → applySettingsToDOM が要素の存在を前提とするため）
   renderLevelCheckboxes();
 
-  // メニューマネージャーを初期化
-  const menuManager = new MenuManager();
+  // メニューマネージャーを初期化（コンストラクタ内で DOM イベントを登録するため、戻り値は保持しない）
+  new MenuManager();
 
   const questionDiv = document.getElementById('question');
   const choiceButtons = document.querySelectorAll('.choice-btn');

--- a/js/storage.js
+++ b/js/storage.js
@@ -19,7 +19,7 @@ export function loadSettings() {
     try {
       const parsed = JSON.parse(storedLevels);
       selectedLevels = Array.isArray(parsed) ? parsed : null;
-    } catch (e) {
+    } catch {
       selectedLevels = null;
     }
   }
@@ -59,7 +59,7 @@ export function loadHistory() {
   if (storedHistory) {
     try {
       return JSON.parse(storedHistory);
-    } catch (e) {
+    } catch {
       return [];
     }
   }
@@ -79,7 +79,7 @@ export function loadMistakes() {
   if (storedMistakes) {
     try {
       return JSON.parse(storedMistakes);
-    } catch (e) {
+    } catch {
       return [];
     }
   }
@@ -174,7 +174,7 @@ export function loadCalendar() {
   if (storedCalendar) {
     try {
       return JSON.parse(storedCalendar);
-    } catch (e) {
+    } catch {
       return {};
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "eslint": "^10.3.0",
         "globals": "^17.6.0",
         "http-server": "^14.1.1"
@@ -95,6 +96,27 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "eslint": "^10.3.0",
     "globals": "^17.6.0",
     "http-server": "^14.1.1"


### PR DESCRIPTION
## Summary

Issue #19 への対応。\`@eslint/js\` をインストールし、\`js.configs.recommended\`
を ESLint 設定に組み込む。検出された既存の 17 違反を全件解消し、\`npm run lint\`
が 0 error で通る状態にする。

Closes #19

## 変更構成 (4 コミット)

1. \`refactor(lint): 💡 ESLint recommended ルールセットを追加\`
   - \`@eslint/js\` を devDependencies に追加
   - \`eslint.config.js\` に \`js.configs.recommended\` を組み込み
   - chart.js の CDN グローバル \`Chart\` を globals に readonly で追加 (no-undef × 3 件を解消)

2. \`refactor(lint): 💡 catch (e) を optional catch binding に置換\`
   - 例外変数 e を使わない catch を ES2019+ の \`catch {\` に置換
   - 対象: analytics.js / badges.js × 2 / storage.js × 4 (合計 7 件)

3. \`refactor(lint): 💡 未使用 import / 不要代入を整理\`
   - main.js: 未使用 \`speakAnswer\` import を削除
   - main.js: \`new MenuManager()\` の戻り値破棄 (副作用目的のため)
   - charts.js: \`weakQuestionsHTML\` の初期化代入を削除

4. \`refactor(lint): 💡 logic.js の hasOwnProperty / case declarations を解消\`
   - \`obj.hasOwnProperty\` の直接呼び出し → \`Object.keys(...)\` ループ
   - case 句内の let/const を \`{ }\` ブロックで囲ってスコープ分離

## ESLint 違反の解消内訳

| ルール | 件数 | 修正方針 |
|---|---|---|
| no-undef (Chart) | 3 | globals に readonly 追加 |
| no-unused-vars (catch e) | 7 | optional catch binding |
| no-unused-vars (import/var) | 2 | 削除 / 代入省略 |
| no-useless-assignment | 1 | 初期代入削除 |
| no-prototype-builtins | 1 | Object.keys ループに置換 |
| no-case-declarations | 3 | \`{ }\` ブロック化 |
| **合計** | **17** | **全件解消** |

## 副次変更

Prettier (or 同等の formatter) が触ったファイル全体でダブル→シングルクォートに
整形。プロジェクトの標準スタイルに合わせるためそのまま受け入れる。

## Test plan

- [x] \`npm run lint\` がローカルで 0 error
- [ ] CI の Cyclomatic Complexity Check が通る
- [ ] CodeQL / Gitleaks / actionlint / markdownlint が通る
- [ ] マージ後の deploy が成功し、サイトのグラフ表示・段選択・モード切替が動く

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * 文字列のクォート表記を全体で統一（ダブル→シングル）

* **Refactor**
  * グラフ描画の初期化・更新方法を整理（データ無い場合の表示切替含む）
  * 問題生成・選択ロジックの内部整理
  * ローカル保存データの読み書き周りの例外処理を簡潔化
  * 一部起動処理の呼び出し方を整理

* **Chores**
  * ESLint設定を更新、開発依存を追加

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/kakezan-manabo/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->