### PR TITLE
refactor(ci): 💡 node-version を "20" → "20.19" に明示化 (closes #32)

### DIFF
--- a/.github/workflows/complexity-check.yml
+++ b/.github/workflows/complexity-check.yml
@@ -23,7 +23,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
-          node-version: "20"
+          # ESLint v10 の engines は ^20.19.0 || ^22.13.0 || >=24
+          # actions/setup-node の "20" 指定は最新の 20.x を解決するため現状は通るが、
+          # 将来の仕様変更で 20.19 未満が選ばれた場合に壊れるリスクがあるため明示化する
+          node-version: "20.19"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
-          # ESLint v10 等が要求する最低 Node バージョンに合わせて明示化
+          # プロジェクト全体で Node.js 20.19 に統一（ESLint v10 の最低要件に合わせて）
           node-version: "20.19"
 
       - name: Install markdownlint-cli2

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -36,7 +36,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
-          node-version: "20"
+          # ESLint v10 等が要求する最低 Node バージョンに合わせて明示化
+          node-version: "20.19"
 
       - name: Install markdownlint-cli2
         # DavidAnson/markdownlint-cli2-action は allowed_actions に含まれない


### PR DESCRIPTION
## Summary

Issue #32 への対応。\`actions/setup-node\` の \`node-version: "20"\` を
\`"20.19"\` に明示化する。

Closes #32

## 背景

PR #29 のレビューで指摘された改善点。\`"20"\` 指定は actions/setup-node の
セマンティクスで現状最新の 20.x が解決されるため CI は通っているが、
将来の仕様変更で 20.19 未満が選ばれた場合 ESLint v10 の engines
(\`^20.19.0 || ^22.13.0 || >=24\`) を満たさず壊れるリスクがある。

最低バージョンを明示することで、セマンティクスのズレに早期気付ける状態にする。

## 横展開

同じ \`"20"\` 指定が以下 2 ファイルにあったため同 PR で揃える:

- \`.github/workflows/complexity-check.yml\` (Issue 本来のスコープ)
- \`.github/workflows/markdownlint.yml\` (横展開、PR #44 で追加されたもの)

## バージョン選択の根拠

| 候補 | 採用 | 理由 |
|---|---|---|
| \`"20.19"\` | ✅ | ESLint v10 の engines 最低値と一致、現行 20 系の挙動を維持 |
| \`"22"\` |  | エコシステム同調は魅力的だが、Node メジャー変更は別 Issue で議論 |

## Test plan

- [ ] Cyclomatic Complexity Check が通る
- [ ] markdownlint-cli2 が起動する (継続失敗は既存方針通り)
- [ ] actionlint が通る

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * GitHub Actions ワークフロー（複雑性チェック、markdownlint）で Node.js のバージョン指定を "20" から "20.19" に明示的に固定し、関連コメントを追加。ESLint v10 等の最低要件に合わせてバージョン解決の安定化を図りました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/kakezan-manabo/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->