### PR TITLE
fix(ui): 🐛 段選択のキャラクターアイコンと関連CSSを復元 (closes #37)

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,7 +132,8 @@
             <template id="level-checkbox-template">
               <label class="level-checkbox">
                 <input type="checkbox" checked />
-                <span></span>
+                <span class="level-icon"></span>
+                <span class="level-text"></span>
               </label>
             </template>
           </div>

--- a/js/level-data.js
+++ b/js/level-data.js
@@ -6,13 +6,13 @@
  * 各要素にプロパティを足すだけで UI に反映される。
  */
 export const LEVELS = [
-  { id: 1, label: '1のだん' },
-  { id: 2, label: '2のだん' },
-  { id: 3, label: '3のだん' },
-  { id: 4, label: '4のだん' },
-  { id: 5, label: '5のだん' },
-  { id: 6, label: '6のだん' },
-  { id: 7, label: '7のだん' },
-  { id: 8, label: '8のだん' },
-  { id: 9, label: '9のだん' },
+  { id: 1, label: '1のだん', icon: '🐶' },
+  { id: 2, label: '2のだん', icon: '🐱' },
+  { id: 3, label: '3のだん', icon: '🐰' },
+  { id: 4, label: '4のだん', icon: '🐻' },
+  { id: 5, label: '5のだん', icon: '🦊' },
+  { id: 6, label: '6のだん', icon: '🐼' },
+  { id: 7, label: '7のだん', icon: '🐯' },
+  { id: 8, label: '8のだん', icon: '🦁' },
+  { id: 9, label: '9のだん', icon: '🐵' },
 ];

--- a/js/level-selector.js
+++ b/js/level-selector.js
@@ -28,10 +28,11 @@ export function renderLevelCheckboxes() {
 
 /**
  * 1段分のチェックボックス要素を template から生成する（内部利用）。
- * 前提: template には `.level-checkbox` / `input[type="checkbox"]` / `span`
- * の各要素が必ず含まれていること（index.html の <template> と契約済み）。
+ * 前提: template には `.level-checkbox` / `input[type="checkbox"]` /
+ * `.level-icon` / `.level-text` の各要素が必ず含まれていること
+ * （index.html の <template> と契約済み）。
  * @param {HTMLTemplateElement} template
- * @param {{ id: number, label: string }} level
+ * @param {{ id: number, label: string, icon: string }} level
  * @returns {DocumentFragment}
  */
 function createLevelCheckbox(template, level) {
@@ -44,8 +45,11 @@ function createLevelCheckbox(template, level) {
   input.id = `level${level.id}`;
   input.value = String(level.id);
 
-  const span = node.querySelector('span');
-  span.textContent = level.label;
+  const icon = node.querySelector('.level-icon');
+  icon.textContent = level.icon;
+
+  const text = node.querySelector('.level-text');
+  text.textContent = level.label;
 
   return node;
 }

--- a/style.css
+++ b/style.css
@@ -1328,124 +1328,147 @@ h3 {
 
 .level-checkbox {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  padding: 12px;
+  justify-content: center;
+  padding: 16px 12px;
   background: var(--color-bg-surface-alt);
   border: 2px solid var(--color-border-soft);
-  border-radius: 8px;
+  border-radius: 12px;
   cursor: pointer;
   transition:
     background 0.2s ease,
-    border-color 0.2s ease;
+    border-color 0.2s ease,
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
   user-select: none;
+  position: relative;
+  min-height: 100px;
 }
 
 .level-checkbox:hover {
   background: var(--color-bg-selected);
   border-color: var(--color-brand-primary);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(102, 126, 234, 0.2);
 }
 
 /* 段ごとのカラーコーディング */
-.level-checkbox[data-level="1"] {
+.level-checkbox[data-level='1'] {
   background: var(--color-dan-1);
   border-color: var(--color-dan-1-border);
 }
 
-.level-checkbox[data-level="1"]:hover {
+.level-checkbox[data-level='1']:hover {
   border-color: var(--color-dan-1-hover);
 }
 
-.level-checkbox[data-level="2"] {
+.level-checkbox[data-level='2'] {
   background: var(--color-dan-2);
   border-color: var(--color-dan-2-border);
 }
 
-.level-checkbox[data-level="2"]:hover {
+.level-checkbox[data-level='2']:hover {
   border-color: var(--color-dan-2-hover);
 }
 
-.level-checkbox[data-level="3"] {
+.level-checkbox[data-level='3'] {
   background: var(--color-dan-3);
   border-color: var(--color-dan-3-border);
 }
 
-.level-checkbox[data-level="3"]:hover {
+.level-checkbox[data-level='3']:hover {
   border-color: var(--color-dan-3-hover);
 }
 
-.level-checkbox[data-level="4"] {
+.level-checkbox[data-level='4'] {
   background: var(--color-dan-4);
   border-color: var(--color-dan-4-border);
 }
 
-.level-checkbox[data-level="4"]:hover {
+.level-checkbox[data-level='4']:hover {
   border-color: var(--color-dan-4-hover);
 }
 
-.level-checkbox[data-level="5"] {
+.level-checkbox[data-level='5'] {
   background: var(--color-dan-5);
   border-color: var(--color-dan-5-border);
 }
 
-.level-checkbox[data-level="5"]:hover {
+.level-checkbox[data-level='5']:hover {
   border-color: var(--color-dan-5-hover);
 }
 
-.level-checkbox[data-level="6"] {
+.level-checkbox[data-level='6'] {
   background: var(--color-dan-6);
   border-color: var(--color-dan-6-border);
 }
 
-.level-checkbox[data-level="6"]:hover {
+.level-checkbox[data-level='6']:hover {
   border-color: var(--color-dan-6-hover);
 }
 
-.level-checkbox[data-level="7"] {
+.level-checkbox[data-level='7'] {
   background: var(--color-dan-7);
   border-color: var(--color-dan-7-border);
 }
 
-.level-checkbox[data-level="7"]:hover {
+.level-checkbox[data-level='7']:hover {
   border-color: var(--color-dan-7-hover);
 }
 
-.level-checkbox[data-level="8"] {
+.level-checkbox[data-level='8'] {
   background: var(--color-dan-8);
   border-color: var(--color-dan-8-border);
 }
 
-.level-checkbox[data-level="8"]:hover {
+.level-checkbox[data-level='8']:hover {
   border-color: var(--color-dan-8-hover);
 }
 
-.level-checkbox[data-level="9"] {
+.level-checkbox[data-level='9'] {
   background: var(--color-dan-9);
   border-color: var(--color-dan-9-border);
 }
 
-.level-checkbox[data-level="9"]:hover {
+.level-checkbox[data-level='9']:hover {
   border-color: var(--color-dan-9-hover);
 }
 
-.level-checkbox input[type="checkbox"] {
-  margin: 0 8px 0 0;
+.level-checkbox input[type='checkbox'] {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  margin: 0;
   width: 20px;
   height: 20px;
   cursor: pointer;
+  accent-color: var(--color-brand-primary);
 }
 
-.level-checkbox input[type="checkbox"]:checked + span {
+.level-checkbox input[type='checkbox']:checked ~ .level-icon {
+  transform: scale(1.1);
+  filter: drop-shadow(0 2px 4px rgba(102, 126, 234, 0.3));
+}
+
+.level-checkbox input[type='checkbox']:checked ~ .level-text {
   font-weight: 700;
   color: var(--color-brand-primary);
 }
 
-.level-checkbox input[type="checkbox"]:checked {
-  accent-color: var(--color-brand-primary);
+.level-icon {
+  font-size: 2.5em;
+  margin-bottom: 8px;
+  transition: all 0.3s ease;
+  line-height: 1;
 }
 
-.level-checkbox span {
+.level-text {
   font-size: 1.05em;
-  transition: color 0.2s ease;
+  transition:
+    color 0.2s ease,
+    font-weight 0.2s ease;
+  text-align: center;
 }
 
 /* 問題数入力 */

--- a/style.css
+++ b/style.css
@@ -1354,88 +1354,88 @@ h3 {
 }
 
 /* 段ごとのカラーコーディング */
-.level-checkbox[data-level='1'] {
+.level-checkbox[data-level="1"] {
   background: var(--color-dan-1);
   border-color: var(--color-dan-1-border);
 }
 
-.level-checkbox[data-level='1']:hover {
+.level-checkbox[data-level="1"]:hover {
   border-color: var(--color-dan-1-hover);
 }
 
-.level-checkbox[data-level='2'] {
+.level-checkbox[data-level="2"] {
   background: var(--color-dan-2);
   border-color: var(--color-dan-2-border);
 }
 
-.level-checkbox[data-level='2']:hover {
+.level-checkbox[data-level="2"]:hover {
   border-color: var(--color-dan-2-hover);
 }
 
-.level-checkbox[data-level='3'] {
+.level-checkbox[data-level="3"] {
   background: var(--color-dan-3);
   border-color: var(--color-dan-3-border);
 }
 
-.level-checkbox[data-level='3']:hover {
+.level-checkbox[data-level="3"]:hover {
   border-color: var(--color-dan-3-hover);
 }
 
-.level-checkbox[data-level='4'] {
+.level-checkbox[data-level="4"] {
   background: var(--color-dan-4);
   border-color: var(--color-dan-4-border);
 }
 
-.level-checkbox[data-level='4']:hover {
+.level-checkbox[data-level="4"]:hover {
   border-color: var(--color-dan-4-hover);
 }
 
-.level-checkbox[data-level='5'] {
+.level-checkbox[data-level="5"] {
   background: var(--color-dan-5);
   border-color: var(--color-dan-5-border);
 }
 
-.level-checkbox[data-level='5']:hover {
+.level-checkbox[data-level="5"]:hover {
   border-color: var(--color-dan-5-hover);
 }
 
-.level-checkbox[data-level='6'] {
+.level-checkbox[data-level="6"] {
   background: var(--color-dan-6);
   border-color: var(--color-dan-6-border);
 }
 
-.level-checkbox[data-level='6']:hover {
+.level-checkbox[data-level="6"]:hover {
   border-color: var(--color-dan-6-hover);
 }
 
-.level-checkbox[data-level='7'] {
+.level-checkbox[data-level="7"] {
   background: var(--color-dan-7);
   border-color: var(--color-dan-7-border);
 }
 
-.level-checkbox[data-level='7']:hover {
+.level-checkbox[data-level="7"]:hover {
   border-color: var(--color-dan-7-hover);
 }
 
-.level-checkbox[data-level='8'] {
+.level-checkbox[data-level="8"] {
   background: var(--color-dan-8);
   border-color: var(--color-dan-8-border);
 }
 
-.level-checkbox[data-level='8']:hover {
+.level-checkbox[data-level="8"]:hover {
   border-color: var(--color-dan-8-hover);
 }
 
-.level-checkbox[data-level='9'] {
+.level-checkbox[data-level="9"] {
   background: var(--color-dan-9);
   border-color: var(--color-dan-9-border);
 }
 
-.level-checkbox[data-level='9']:hover {
+.level-checkbox[data-level="9"]:hover {
   border-color: var(--color-dan-9-hover);
 }
 
-.level-checkbox input[type='checkbox'] {
+.level-checkbox input[type="checkbox"] {
   position: absolute;
   top: 8px;
   right: 8px;
@@ -1446,12 +1446,12 @@ h3 {
   accent-color: var(--color-brand-primary);
 }
 
-.level-checkbox input[type='checkbox']:checked ~ .level-icon {
+.level-checkbox input[type="checkbox"]:checked ~ .level-icon {
   transform: scale(1.1);
   filter: drop-shadow(0 2px 4px rgba(102, 126, 234, 0.3));
 }
 
-.level-checkbox input[type='checkbox']:checked ~ .level-text {
+.level-checkbox input[type="checkbox"]:checked ~ .level-text {
   font-weight: 700;
   color: var(--color-brand-primary);
 }
@@ -1523,7 +1523,12 @@ h3 {
     padding: 10px 8px;
   }
 
-  .level-checkbox span {
+  .level-icon {
+    font-size: 2em;
+    margin-bottom: 6px;
+  }
+
+  .level-text {
     font-size: 1em;
   }
 }


### PR DESCRIPTION
## Summary

Issue #37 への対応。PR #14 で導入されたキャラクターアイコン (🐶🐱🐰🐻🦊🐼🐯🦁🐵) と
関連 CSS が PR #15 のマージ時に上書きで失われていた regression を復元する。

Closes #37

## 背景

- 起源: PR #14 (MERGED 2025-11-23) — 段選択にキャラクターアイコンを追加
- 上書きされた PR: #15 — カラーコーディング適用時に上書き
- 発見契機: Issue #17 の調査中に main から失われていることが判明

## 復元アプローチ

Issue #17 (PR #38) で導入されたデータ駆動の段選択構造を活かす:

1. **\`js/level-data.js\`**: \`LEVELS\` 配列に \`icon\` フィールドを追加
2. **\`js/level-selector.js\`**: \`.level-icon\` と \`.level-text\` を別 span として埋める
3. **\`index.html\`**: \`<template>\` 内に \`.level-icon\` と \`.level-text\` の 2 span を配置
4. **\`style.css\`**:
   - \`.level-checkbox\` を縦並び (flex-direction: column) に変更
   - hover 時の浮き上がりアニメーション (transform / box-shadow) 追加
   - チェック時にアイコンが拡大する \`:checked ~ .level-icon\` 演出を復元
   - **PR #15 のカラーコーディング (data-level 別) は変更せず維持**

## アイコン割当

| 段 | アイコン |
|---:|:---|
| 1 | 🐶 犬 |
| 2 | 🐱 猫 |
| 3 | 🐰 うさぎ |
| 4 | 🐻 くま |
| 5 | 🦊 きつね |
| 6 | 🐼 パンダ |
| 7 | 🐯 トラ |
| 8 | 🦁 ライオン |
| 9 | 🐵 さる |

## Test plan

- [x] \`npm run lint\` がローカルで通る
- [ ] CI (Cyclomatic Complexity / actionlint / codeql / gitleaks / markdownlint) が通る
- [ ] マージ後、設定ページの段選択にアイコンが表示され、チェック時に拡大演出が出る
- [ ] PR #15 のカラーコーディング (段ごとの背景色) が引き続き反映されている

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * レベル選択に各レベル用の絵文字アイコンが追加され、選択肢の視認性が向上しました。

* **スタイル**
  * レベルセレクタのレイアウトと見た目を刷新（縦並びカード表示、角丸、最小高さ、右上のチェック配置など）。
  * ホバー時のアニメーション（浮き上がり・影）や選択時のアイコン拡大・テキスト強調を追加。
  * モバイル向けにフォントサイズ・間隔を調整。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genzouw/kakezan-manabo/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->