### PR TITLE
ci: 🔒 CodeQL に actions 言語を追加して workflow 権限を継続スキャン

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['javascript-typescript']
+        language: ['javascript-typescript', 'actions']
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- Code scanning alert [#1](https://github.com/genzouw/kakezan-manabo/security/code-scanning/1) (`actions/missing-workflow-permissions`) は PR #39 で `permissions: contents: read` を追加し既にコード上は修正済み
- しかし現在の `codeql.yml` の matrix が `javascript-typescript` のみで `actions` 言語をスキャンしないため、アラートが再分析されず `open` のまま残存している
- `language` matrix に `actions` を追加し、次回 CodeQL スキャン実行時に stale なアラートが自動クローズされるようにする

## Effects

- 既存アラート #1 が次回 CodeQL 実行で `fixed` に自動遷移
- 今後 workflow ファイルを変更した際も `permissions` 未指定などの問題を継続的に検知可能

## Test plan

- [ ] PR マージ後、`CodeQL` workflow が成功すること
- [ ] マージ後に [code scanning alerts](https://github.com/genzouw/kakezan-manabo/security/code-scanning) を確認し、alert #1 が `Fixed` 状態になっていること