### PR TITLE
fix(ci): 🔧 markdownlint を npm 経由実行へ再切替し startup_failure を再発防止

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -33,8 +33,19 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Run markdownlint-cli2
-        uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # v23.2.0
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          config: '.markdownlint-cli2.jsonc'
-          globs: '**/*.md'
+          # ESLint v10 等の最低要件に合わせて他 workflow と同じ 20.19 を明示
+          node-version: '20.19'
+
+      - name: Install markdownlint-cli2
+        # DavidAnson/markdownlint-cli2-action は third-party action のため
+        # repo の allowed_actions (patterns_allowed) に登録されている事が
+        # 起動条件となり、許可リストから漏れると startup_failure になる。
+        # 過去 PR #44 と同じ方針で npm 経由実行に戻し、許可リストへの依存を排除する。
+        # --ignore-scripts で postinstall 経由の任意コード実行を抑止する。
+        run: npm install -g --no-fund --no-audit --ignore-scripts markdownlint-cli2@0.22.1
+
+      - name: Run markdownlint-cli2
+        run: markdownlint-cli2 --config .markdownlint-cli2.jsonc "**/*.md"


### PR DESCRIPTION
## Summary

- 過去 8 連続 `startup_failure` の markdownlint workflow を、PR #44 と同じ npm 経由実行へ戻して復旧する
- `DavidAnson/markdownlint-cli2-action` を撤去し、`allowed_actions` (`patterns_allowed`) への依存をワークフロー側から排除する
- 経緯と意図を workflow 本文にコメントで残し、再々度のリグレッションを抑止する

## 失敗 Run

https://github.com/genzouw/kakezan-manabo/actions/runs/26388299802 (`startup_failure`、ジョブ 0 件)

5/21 (PR #55) で action 利用へ戻して以降、`gh run list --workflow markdownlint.yml` の通り直近 8 回連続で `startup_failure`。

## 原因

`DavidAnson/markdownlint-cli2-action` は third-party の Marketplace action。
本リポジトリの `allowed_actions` は `selected` + `github_owned_allowed=true` + `verified_allowed=true` で運用しており、`patterns_allowed` に登録されていない third-party action は SHA pin していても起動拒否 (`startup_failure`) となる。

PR #44 ではまさにこの事象を解消するため npm 経由実行へ切り替えたが、PR #55 で action 利用へ意図せず差し戻されていた。

`genzouw/genzouw.com` 側の terraform (commit `f5af9f3`、2026-05-26) で `DavidAnson/markdownlint-cli2-action@*` を `patterns_allowed` に追加して GitHub 側の許可は復旧済みだが、許可リストへの依存自体が壊れやすい構造のため、ワークフロー側でも依存を取り除く。

## 変更内容

- `actions/setup-node@v6.4.0` で Node.js `20.19` をセットアップ (他 workflow と統一)
- `npm install -g --no-fund --no-audit --ignore-scripts markdownlint-cli2@0.22.1` でインストール
  - `--ignore-scripts`: postinstall 経由の任意コード実行を防止
- `markdownlint-cli2 --config .markdownlint-cli2.jsonc "**/*.md"` を直接実行
- `continue-on-error: true` は既存方針 (MD040/MD031 整理後に外す) に従い据え置き
- 経緯と意図を workflow に日本語コメントで明記

## Terraform 側について

`genzouw.com` の `actions_patterns_allowed` で `DavidAnson/markdownlint-cli2-action@*` は既に許可されている状態。本 PR では terraform は変更しない。

将来このパターンを掃除する場合、本 workflow に依存が無いことを確認してから削除可能。

## Test plan

- [ ] 本 PR の `pull_request` イベントで markdownlint workflow が `startup_failure` せず起動する
- [ ] `markdownlint-cli2` が実行され、レポートが出力される (継続失敗時も `continue-on-error` で全体は通る)
- [ ] `actionlint` が通る